### PR TITLE
Added functionality for repeating questions

### DIFF
--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -33,7 +33,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -120,6 +120,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/CarCounting.vue
+++ b/src/pages/GameZone/GameZoneList/CarCounting.vue
@@ -31,7 +31,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -131,6 +131,11 @@ const playNextQuestion = async () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -30,7 +30,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -113,6 +113,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -30,7 +30,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -113,6 +113,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -34,7 +34,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -121,6 +121,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -33,7 +33,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -119,6 +119,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -33,7 +33,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -120,6 +120,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -33,7 +33,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -119,6 +119,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/OddOneOut.vue
+++ b/src/pages/GameZone/GameZoneList/OddOneOut.vue
@@ -30,7 +30,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -113,6 +113,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -30,7 +30,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -113,6 +113,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -30,7 +30,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -113,6 +113,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -33,7 +33,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -119,6 +119,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/SpellingBee.vue
+++ b/src/pages/GameZone/GameZoneList/SpellingBee.vue
@@ -30,7 +30,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -113,6 +113,12 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
+        playQuestion(question["Q"]);
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -33,7 +33,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -119,6 +119,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -30,7 +30,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -113,6 +113,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&

--- a/src/pages/GameZone/GameZoneList/Vocab.vue
+++ b/src/pages/GameZone/GameZoneList/Vocab.vue
@@ -30,7 +30,7 @@
             >
                 <div class="flex flex-row gap-4">
                     <div class="p-2 px-5 text-[#087bb4]">
-                        &#9432; Hold 'SPACE' to say the answer
+                        &#9432; Hold 'SPACE' to say the answer | Press 'R' to repeat question
                     </div>
                 </div>
                 <div
@@ -113,6 +113,11 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
+    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+        playNextQuestion();
+        return;
+    }
+
     if (
         event.code === "Space" &&
         !isListening.value &&


### PR DESCRIPTION
# 'Repeat Question' Feature Across All Games

## Changes Made
- Added the ability to repeat the current question by pressing 'R' key across all 16 games
- Updated instruction text in all games to inform users about the repeat question feature
- Implemented consistent behavior across all games for question repetition

## Games Modified
1. Addition Game
2. Car Counting
3. Color Game
4. Definition Detective
5. Division Duel
6. Fruit Frenzy
7. Monkey Madness
8. Multiplication Madness
9. Odd One Out
10. Part of Speech
11. Polar Pairing
12. Shape Shark
13. Spelling Bee
14. Subtraction Game
15. Syllable Sorting
16. Vocabulary Vortex

## Implementation Details
- Added 'R' key handler in each game's handleKeyDown function
- Added instruction text: "Hold 'SPACE' to say the answer | Press 'R' to repeat question"
- Uses existing playNextQuestion() function to replay current question