### PR TITLE
Fixed audio overlap for questions

### DIFF
--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -77,7 +77,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 let allQuestionslength = 0;
 
@@ -120,7 +121,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < allQuestionslength && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -128,7 +131,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < allQuestionslength
+        numOfAudiosPlayed.value < allQuestionslength &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -183,9 +187,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/animalAddition/additionintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -74,7 +74,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 // Generate multiplication questions using Json file
 const generateQuestions = () => {
@@ -113,7 +114,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < 5 && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -121,7 +124,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < 5
+        numOfAudiosPlayed.value < 5 &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -174,9 +178,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/colorGame/colorIntro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -74,7 +74,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 // Generate multiplication questions using Json file
 const generateQuestions = () => {
@@ -113,7 +114,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < 5 && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -121,7 +124,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < 5
+        numOfAudiosPlayed.value < 5 &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -174,11 +178,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
-            const introAudio = playIntro(
-                "/definitionDetective/definitionIntro.mp3"
-            );
+            isIntroPlaying.value = true;
+            const introAudio = playIntro("/definitionDetective/definitionIntro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -78,7 +78,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 let allQuestionslength = 0;
 
@@ -121,7 +122,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < allQuestionslength && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -129,7 +132,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < allQuestionslength
+        numOfAudiosPlayed.value < allQuestionslength &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -183,9 +187,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/divisionduel/divintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -77,7 +77,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 let allQuestionslength = 0;
 // Generate multiplication questions using Json file
@@ -119,7 +120,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < allQuestionslength && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -127,7 +130,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < allQuestionslength
+        numOfAudiosPlayed.value < allQuestionslength &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -181,9 +185,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/fruitFrenzy/fruitIntro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -77,7 +77,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 let allQuestionslength = 0;
 
@@ -120,7 +121,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < allQuestionslength && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -128,7 +131,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < allQuestionslength
+        numOfAudiosPlayed.value < allQuestionslength &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -182,9 +186,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/monkeyMadness/monkeyintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -77,7 +77,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 let allQuestionslength = 0;
 
 // Generate multiplication questions using Json file
@@ -119,7 +120,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < allQuestionslength && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -127,7 +130,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < allQuestionslength
+        numOfAudiosPlayed.value < allQuestionslength &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -181,11 +185,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
-            const introAudio = playIntro(
-                "/multiplicationmadness/multiplicationintro.mp3"
-            );
+            isIntroPlaying.value = true;
+            const introAudio = playIntro("/multiplicationmadness/multiplicationintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/OddOneOut.vue
+++ b/src/pages/GameZone/GameZoneList/OddOneOut.vue
@@ -74,7 +74,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 // Generate multiplication questions using Json file
 const generateQuestions = () => {
@@ -113,7 +114,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < 5 && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -121,7 +124,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < 5
+        numOfAudiosPlayed.value < 5 &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -174,9 +178,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/oddoneout/oddoneoutintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -74,7 +74,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 // Generate multiplication questions using Json file
 const generateQuestions = () => {
@@ -113,7 +114,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < 5 && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -121,7 +124,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < 5
+        numOfAudiosPlayed.value < 5 &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -174,9 +178,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/partOfSpeech/partofspeechintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -74,7 +74,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 // Generate multiplication questions using Json file
 const generateQuestions = () => {
@@ -113,7 +114,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < 5 && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -121,7 +124,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < 5
+        numOfAudiosPlayed.value < 5 &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -174,9 +178,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/polarpairing/oppintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -77,7 +77,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 let allQuestionslength = 0;
 
 // Generate multiplication questions using Json file
@@ -119,7 +120,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < allQuestionslength && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -127,7 +130,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < allQuestionslength
+        numOfAudiosPlayed.value < allQuestionslength &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -181,9 +185,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/shapeSharks/shapeintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/SpellingBee.vue
+++ b/src/pages/GameZone/GameZoneList/SpellingBee.vue
@@ -74,7 +74,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 // Generate multiplication questions using Json file
 const generateQuestions = () => {
@@ -113,7 +114,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < 5 && 
+        !isIntroPlaying.value) {
         const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
         playQuestion(question["Q"]);
         return;
@@ -122,7 +125,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < 5
+        numOfAudiosPlayed.value < 5 &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -175,9 +179,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/spellingBee/spellingintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -77,7 +77,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 let allQuestionslength = 0;
 // Generate multiplication questions using Json file
@@ -119,7 +120,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < allQuestionslength) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < allQuestionslength && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -127,7 +130,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < allQuestionslength
+        numOfAudiosPlayed.value < allQuestionslength &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -181,11 +185,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
-            const introAudio = playIntro(
-                "/subtractionSafari/subtractionintro.mp3"
-            );
+            isIntroPlaying.value = true;
+            const introAudio = playIntro("/subtractionSafari/subtractionintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -74,7 +74,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 // Generate multiplication questions using Json file
 const generateQuestions = () => {
@@ -113,7 +114,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < 5 && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -121,7 +124,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < 5
+        numOfAudiosPlayed.value < 5 &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -174,9 +178,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/syllableSorting/syllableIntro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 

--- a/src/pages/GameZone/GameZoneList/Vocab.vue
+++ b/src/pages/GameZone/GameZoneList/Vocab.vue
@@ -74,7 +74,8 @@ let numOfAudiosPlayed = ref(0),
 let questionsDb = [],
     isListening = ref(false),
     transcription = ref(""),
-    playButton = ref(false);
+    playButton = ref(false),
+    isIntroPlaying = ref(false);
 
 // Generate multiplication questions using Json file
 const generateQuestions = () => {
@@ -113,7 +114,9 @@ const playNextQuestion = () => {
 
 // Handle the spacebar events
 const handleKeyDown = (event) => {
-    if (event.code === "KeyR" && numOfAudiosPlayed.value < 5) {
+    if (event.code === "KeyR" && 
+        numOfAudiosPlayed.value < 5 && 
+        !isIntroPlaying.value) {
         playNextQuestion();
         return;
     }
@@ -121,7 +124,8 @@ const handleKeyDown = (event) => {
     if (
         event.code === "Space" &&
         !isListening.value &&
-        numOfAudiosPlayed.value < 5
+        numOfAudiosPlayed.value < 5 &&
+        !isIntroPlaying.value
     ) {
         isListening.value = true;
         startListening((transcript) => {
@@ -174,9 +178,13 @@ onMounted(() => {
 
     watch(playButton, (newVal) => {
         if (newVal) {
+            isIntroPlaying.value = true;
             const introAudio = playIntro("/vocabVortex/vortexintro.mp3");
             currentAudios.push(introAudio);
-            introAudio.onended = playNextQuestion;
+            introAudio.onended = () => {
+                isIntroPlaying.value = false;
+                playNextQuestion();
+            };
         }
     });
 


### PR DESCRIPTION
The user was able to repeat the questions before the intro audio was played completely, which could also result in an overlap between the audios. Fixed it