### PR TITLE
Fixed stopping audio in back buttons

### DIFF
--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -293,7 +293,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/CarCounting.vue
+++ b/src/pages/GameZone/GameZoneList/CarCounting.vue
@@ -290,7 +290,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -287,7 +287,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -287,7 +287,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -288,7 +288,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -291,7 +291,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -288,7 +288,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -290,7 +290,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/OddOneOut.vue
+++ b/src/pages/GameZone/GameZoneList/OddOneOut.vue
@@ -289,7 +289,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -288,7 +288,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -285,7 +285,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -290,7 +290,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/SpellingBee.vue
+++ b/src/pages/GameZone/GameZoneList/SpellingBee.vue
@@ -295,7 +295,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -290,7 +290,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -288,7 +288,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize

--- a/src/pages/GameZone/GameZoneList/Vocab.vue
+++ b/src/pages/GameZone/GameZoneList/Vocab.vue
@@ -289,7 +289,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
-  window.history.back();
+  // Force navigate to the game zone page
+  window.location.href = "/game-zone";
 };
 
 // Check device type on mount and on window resize


### PR DESCRIPTION
# 🔊 Fix: Stop All Audio Playback When Back Button is Clicked

## Problem
Users experienced an issue where Text-to-Speech (TTS) audio would continue playing even after navigating away from game pages using the back button. This created a poor user experience as audio from previous games would overlap with new content.

## Solution
Implemented a force navigation approach in all 16 game files to ensure complete termination of all audio processes when the user clicks the back button. Instead of using the standard history navigation (`window.history.back()`), we now redirect users directly to the game zone page (`window.location.href = "/game-zone"`), which forces a complete page reload and stops all audio processes.

## Files Changed - All 16 game files

## Testing
- Verified that all audio (including TTS) stops immediately when the back button is clicked
- Tested on multiple devices (desktop, tablet, mobile) to ensure consistent behavior
- Confirmed that navigation to the game zone page works correctly

## Notes
While this approach is slightly more abrupt than using history navigation (as it forces a full page reload), it provides a much better user experience by ensuring no audio continues to play after leaving a game. The trade-off between smooth navigation and proper audio termination favors the latter for a better overall experience.