### PR TITLE
Fix: Fixed back navigation to return to correct game zone using sessionStorage

### DIFF
--- a/src/Utilities/playAudio.js
+++ b/src/Utilities/playAudio.js
@@ -57,7 +57,15 @@ export function playAudioPath(path) {
     return new Promise((resolve) => {
         let audio = new Audio(path);
         currentAudios.push(audio); // Track the audio in the array
-        audio.play();
+        audio.play()
+            .then(() => {
+                console.log("Audio playback started successfully.");
+                resolve();
+            })
+            .catch((err) => {
+                console.warn("⚠️ Playback blocked or failed:", err);
+                resolve();
+            });
 
         // audio.onplay = () => {
         //     this.isRecording = true;

--- a/src/pages/GameZone/GameZone.vue
+++ b/src/pages/GameZone/GameZone.vue
@@ -2,11 +2,26 @@
 import Header from "../../components/Header/Header.vue";
 import GameZoneList from "../GameZone/GameZoneList/GameZoneList.vue";
 import GameProgress from "../GameZone/GameProgress/GameProgress.vue";
-import { ref } from "vue";
+import { ref, onMounted } from "vue";
 const currentPage = ref(1);
 const changeCurrentPage = (page) => {
   currentPage.value = page;
 };
+
+onMounted(() => {
+  const category = sessionStorage.getItem("gameCategory");
+
+  if (category === "math") {
+    changeCurrentPage(2); // Math Games
+  } else {
+    changeCurrentPage(1); // Language Games or default
+  }
+
+  // Clear it after use
+  sessionStorage.removeItem("gameCategory");
+});
+
+
 </script>
 <template>
   <div

--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -307,6 +307,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
+  // Save the source category to sessionStorage
+  sessionStorage.setItem("gameCategory", "math");
   // Force navigate to the game zone page
   window.location.href = "/game-zone";
 };

--- a/src/pages/GameZone/GameZoneList/CarCounting.vue
+++ b/src/pages/GameZone/GameZoneList/CarCounting.vue
@@ -308,6 +308,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
+  // Save the source category to sessionStorage
+  sessionStorage.setItem("gameCategory", "math");
   // Force navigate to the game zone page
   window.location.href = "/game-zone";
 };

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#EACAFF]' : 'bg-[#EACAFF]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#EACAFF]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -27,7 +24,7 @@
           <img
             src="/assets/gameImages/cloud-bg-Tab-left.png"
             alt="Decorative cloud"
-            style="width: 300px; height: auto"
+            class="w-[300px] h-auto"
           />
           <!-- Paper plane above left cloud -->
           <div
@@ -46,12 +43,12 @@
           <img
             src="/assets/gameImages/cloud-bg-Tab-right.png"
             alt="Decorative cloud"
-            style="width: 300px; height: auto"
+            class="w-[300px] h-auto"
           />
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -150,8 +147,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
-              <!-- Different button styling for tablet -->
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
+              <!-- Game Control Buttons -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -238,8 +251,13 @@
                 </button>
               </div>
 
+              <!-- Transcript -->
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -263,7 +281,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -281,6 +299,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -298,11 +317,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -363,7 +382,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       // Start listening in continuous mode
       startListening((transcript) => {
         // Just update the transcription in real-time
@@ -376,14 +395,18 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
-      if (question["A"].map(str => str.toLowerCase()).includes(finalTranscript.trim().toLowerCase())) {
+
+      if (
+        question["A"]
+          .map((str) => str.toLowerCase())
+          .includes(finalTranscript.trim().toLowerCase())
+      ) {
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");
@@ -393,18 +416,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -450,6 +473,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -469,7 +499,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#9AE2EB]' : 'bg-[#9AE2EB]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#9AE2EB]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -51,7 +48,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -150,8 +147,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
               <!-- Different button styling for tablet -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -240,6 +253,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -263,7 +280,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -281,6 +298,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -298,11 +316,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -366,7 +384,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -376,14 +394,18 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
-      if (question["A"].map(str => str.toLowerCase()).includes(finalTranscript.trim().toLowerCase())) {
+
+      if (
+        question["A"]
+          .map((str) => str.toLowerCase())
+          .includes(finalTranscript.trim().toLowerCase())
+      ) {
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");
@@ -393,18 +415,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -450,6 +472,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -469,7 +498,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -304,6 +304,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
+  // Save the source category to sessionStorage
+  sessionStorage.setItem("gameCategory", "math");
   // Force navigate to the game zone page
   window.location.href = "/game-zone";
 };

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#6FFFC6]' : 'bg-[#6FFFC6]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#6FFFC6]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -51,7 +48,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -149,8 +146,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
-              <!-- Different button styling for tablet -->
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
+              <!-- Game control buttons -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -239,6 +252,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -262,7 +279,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -280,6 +297,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -297,11 +315,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -335,7 +353,7 @@ const generateQuestions = () => {
         ...data["DivisionGame"]["Questions"]["Medium"],
         ...data["DivisionGame"]["Questions"]["Hard"],
       ];
-      
+
       // Only generate 5 random questions
       while (randQueNum.length < 5) {
         let num = Math.floor(Math.random() * allQuestions.length);
@@ -368,7 +386,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -378,14 +396,18 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
-      if (question["A"].map(str => str.toLowerCase()).includes(finalTranscript.trim().toLowerCase())) {
+
+      if (
+        question["A"]
+          .map((str) => str.toLowerCase())
+          .includes(finalTranscript.trim().toLowerCase())
+      ) {
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");
@@ -395,18 +417,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -453,6 +475,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -472,7 +501,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#FFC5C5]' : 'bg-[#FFC5C5]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#FFC5C5]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -52,7 +49,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -152,8 +149,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
-              <!-- Different button styling for tablet -->
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
+              <!-- Game control buttons -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -242,6 +255,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -265,7 +282,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -283,6 +300,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -300,11 +318,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -336,7 +354,7 @@ const generateQuestions = () => {
         ...data["FruitFrenzy"]["Questions"]["Medium"],
         ...data["FruitFrenzy"]["Questions"]["Hard"],
       ];
-      
+
       // Only generate 5 random questions
       while (randQueNum.length < 5) {
         let num = Math.floor(Math.random() * allQuestions.length);
@@ -373,7 +391,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -383,13 +401,13 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
+
       const answers = question["A"].map((ans) => ans.toLowerCase());
       if (answers.includes(finalTranscript.trim().toLowerCase())) {
         score.value++;
@@ -401,18 +419,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -459,6 +477,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -478,7 +503,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -307,6 +307,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
+  // Save the source category to sessionStorage
+  sessionStorage.setItem("gameCategory", "math");
   // Force navigate to the game zone page
   window.location.href = "/game-zone";
 };

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -304,6 +304,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
+  // Save the source category to sessionStorage
+  sessionStorage.setItem("gameCategory", "math");
   // Force navigate to the game zone page
   window.location.href = "/game-zone";
 };

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#F9AEB0]' : 'bg-[#F9AEB0]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#F9AEB0]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -52,7 +49,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -149,8 +146,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
-              <!-- Different button styling for tablet -->
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
+              <!-- Game control buttons -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -239,6 +252,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -262,7 +279,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -280,6 +297,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -297,11 +315,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -335,7 +353,7 @@ const generateQuestions = () => {
         ...data["MonkeyMadnessGame"]["Questions"]["Medium"],
         ...data["MonkeyMadnessGame"]["Questions"]["Hard"],
       ];
-      
+
       // Only generate 5 random questions
       while (randQueNum.length < 5) {
         let num = Math.floor(Math.random() * allQuestions.length);
@@ -367,7 +385,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -377,13 +395,13 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
+
       const answers = question["A"].map((ans) => ans.toLowerCase());
       if (answers.includes(finalTranscript.trim().toLowerCase())) {
         score.value++;
@@ -395,18 +413,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -452,6 +470,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -471,7 +496,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#AEB9FF]' : 'bg-[#AEB9FF]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#AEB9FF]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -52,7 +49,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -151,8 +148,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
-              <!-- Different button styling for tablet -->
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
+              <!-- Game control buttons -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -241,6 +254,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -264,7 +281,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -282,6 +299,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -299,11 +317,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -339,7 +357,7 @@ const generateQuestions = () => {
         ...data["MultiplicationGame"]["Questions"]["Medium"],
         ...data["MultiplicationGame"]["Questions"]["Hard"],
       ];
-      
+
       // Only generate 5 random questions
       while (randQueNum.length < 5) {
         let num = Math.floor(Math.random() * allQuestions.length);
@@ -372,7 +390,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -382,13 +400,13 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
+
       const answers = question["A"].map((ans) => ans.toLowerCase());
       if (answers.includes(finalTranscript.trim().toLowerCase())) {
         score.value++;
@@ -400,18 +418,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -458,6 +476,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -479,7 +504,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -306,6 +306,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
+  // Save the source category to sessionStorage
+  sessionStorage.setItem("gameCategory", "math");
   // Force navigate to the game zone page
   window.location.href = "/game-zone";
 };

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#6FFFC6]' : 'bg-[#6FFFC6]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#6FFFC6]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -52,7 +49,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -151,8 +148,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
               <!-- Different button styling for tablet -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -241,6 +254,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -264,7 +281,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -282,6 +299,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -299,11 +317,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -363,7 +381,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -373,14 +391,18 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
-      if (question["A"].map(str => str.toLowerCase()).includes(finalTranscript.trim().toLowerCase())) {
+
+      if (
+        question["A"]
+          .map((str) => str.toLowerCase())
+          .includes(finalTranscript.trim().toLowerCase())
+      ) {
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");
@@ -390,18 +412,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -447,6 +469,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -466,7 +495,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#EAD2B0]' : 'bg-[#EAD2B0]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#EAD2B0]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -52,7 +49,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -152,8 +149,24 @@
               class="flex flex-col p-4 justify-center items-center w-full max-w-2xl"
               id="content"
             >
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
               <!-- Different button styling for tablet -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -238,6 +251,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -261,7 +278,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -279,6 +296,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -296,11 +314,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -390,7 +408,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -400,14 +418,18 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
-      if (question["A"].map(str => str.toLowerCase()).includes(finalTranscript.trim().toLowerCase())) {
+
+      if (
+        question["A"]
+          .map((str) => str.toLowerCase())
+          .includes(finalTranscript.trim().toLowerCase())
+      ) {
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");
@@ -417,18 +439,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -443,6 +465,13 @@ const toggleRecording = () => {
       }, 1000);
     }
   }
+};
+
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
 };
 
 onMounted(() => {
@@ -464,7 +493,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#8FD5F8]' : 'bg-[#8FD5F8]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#8FD5F8]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -52,7 +49,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -151,8 +148,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
-              <!-- Different button styling for tablet -->
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
+              <!-- Game control buttons -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -241,6 +254,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -264,7 +281,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -282,6 +299,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -299,11 +317,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -337,7 +355,7 @@ const generateQuestions = () => {
         ...data["ShapeSharkGame"]["Questions"]["Medium"],
         ...data["ShapeSharkGame"]["Questions"]["Hard"],
       ];
-      
+
       // Only generate 5 random questions
       while (randQueNum.length < 5) {
         let num = Math.floor(Math.random() * allQuestions.length);
@@ -369,7 +387,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -379,13 +397,13 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
+
       const answers = question["A"].map((ans) => ans.toLowerCase());
       if (answers.includes(finalTranscript.trim().toLowerCase())) {
         score.value++;
@@ -397,18 +415,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -455,6 +473,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -474,7 +499,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -306,6 +306,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
+  // Save the source category to sessionStorage
+  sessionStorage.setItem("gameCategory", "math");
   // Force navigate to the game zone page
   window.location.href = "/game-zone";
 };

--- a/src/pages/GameZone/GameZoneList/SpellingBee.vue
+++ b/src/pages/GameZone/GameZoneList/SpellingBee.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#FAE9B6]' : 'bg-[#FAE9B6]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#FAE9B6]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -55,7 +52,7 @@
       </template>
 
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -159,8 +156,24 @@
               class="flex flex-col p-4 justify-center items-center"
               id="content"
             >
-              <!-- Different button styling for tablet -->
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
+              <!-- Game control buttons -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -249,6 +262,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -289,6 +306,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -306,11 +324,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -372,7 +390,7 @@ const toggleRecording = () => {
       // Start recording
       isRecording.value = true;
       isListening.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -382,14 +400,18 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
-      if (question["A"].map(str => str.toLowerCase()).includes(finalTranscript.trim().toLowerCase())) {
+
+      if (
+        question["A"]
+          .map((str) => str.toLowerCase())
+          .includes(finalTranscript.trim().toLowerCase())
+      ) {
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");
@@ -399,19 +421,19 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isListening.value = false;
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -454,6 +476,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Check device type on mount
   checkDeviceType();
@@ -473,7 +502,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -306,6 +306,8 @@ const goBack = () => {
   console.log("Going back...");
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
+  // Save the source category to sessionStorage
+  sessionStorage.setItem("gameCategory", "math");
   // Force navigate to the game zone page
   window.location.href = "/game-zone";
 };

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="min-h-screen font-poppins"
-    :class="[isTablet || isMobile ? 'bg-[#BCC5FF]' : 'bg-[#BCC5FF]']"
-  >
+  <div class="min-h-screen font-poppins bg-[#BCC5FF]">
     <!-- Header -->
     <div class="w-full">
       <GamePagesHeader />
@@ -52,7 +49,7 @@
         </div>
       </template>
       <!-- Clouds for desktop -->
-      <template v-else-if="!isMobile">
+      <template v-else-if="isDesktop">
         <div class="absolute bottom-0 left-0 z-0" style="bottom: 50px">
           <img
             src="/assets/gameImages/cloud-bg.png"
@@ -151,8 +148,24 @@
               class="flex flex-col p-4 justify-center"
               id="content"
             >
-              <!-- Different button styling for tablet -->
+              <!-- Mobile/Tablet Start Questions Button - Only show before questions start -->
+              <div v-if="(isTablet || isMobile) && numOfAudiosPlayed === 0">
+                <button
+                  @click="startFirstQuestion"
+                  class="bg-[#087bb4] text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-[#0d5f8b] mb-6"
+                  :disabled="isIntroPlaying"
+                  :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+                >
+                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                </button>
+              </div>
+
+              <!-- Game control buttons -->
               <div
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 :class="[
                   isTablet
                     ? 'flex gap-[25px] mb-6'
@@ -241,6 +254,10 @@
 
               <div
                 id="transcript"
+                v-show="
+                  !(isTablet || isMobile) ||
+                  (!isIntroPlaying && numOfAudiosPlayed > 0)
+                "
                 class="text-center text-xl font-bold pt-2 pb-1"
               >
                 You said: {{ transcription }}
@@ -264,7 +281,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch, computed } from "vue";
 import GamePagesHeader from "../../Header/GamePagesHeader.vue";
 import { requestMicPermission } from "../../../Utilities/requestMicAccess";
 import {
@@ -282,6 +299,7 @@ import {
 // Device detection
 const isTablet = ref(false);
 const isMobile = ref(false);
+const isDesktop = computed(() => !isTablet.value && !isMobile.value);
 
 // Function to handle back button click
 const goBack = () => {
@@ -299,11 +317,11 @@ const checkDeviceType = () => {
     // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
-  } else if (width >= 768 && width <= 1024) { 
+  } else if (width >= 768 && width <= 1024) {
     // Medium devices (tablets, including iPad Pro width)
     isTablet.value = true;
     isMobile.value = false;
-  } else if (width > 1024) { 
+  } else if (width > 1024) {
     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
@@ -367,7 +385,7 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      
+
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
@@ -377,14 +395,18 @@ const toggleRecording = () => {
 
       // Get the final transcript
       const finalTranscript = transcription.value;
-      
+
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
       console.log("Question is: ", question["Q"]);
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
-      
-      if (question["A"].map(str => str.toLowerCase()).includes(finalTranscript.trim().toLowerCase())) {
+
+      if (
+        question["A"]
+          .map((str) => str.toLowerCase())
+          .includes(finalTranscript.trim().toLowerCase())
+      ) {
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");
@@ -394,18 +416,18 @@ const toggleRecording = () => {
         const incorectAudio = "The correct answer is " + question["A"][0];
         currentAudios.push(playQuestion(incorectAudio));
       }
-      
+
       // Stop listening
       stopListening();
       isRecording.value = false;
       numOfAudiosPlayed.value++;
-      
+
       // Reset transcription for next question
       setTimeout(() => {
         transcription.value = "";
         isButtonCooldown.value = false;
         console.log("Recording processed and stopped");
-        
+
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
@@ -452,6 +474,13 @@ const repeatQuestion = () => {
   }
 };
 
+// Add new function to handle first question start
+const startFirstQuestion = () => {
+  console.log("Starting first question...");
+  numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
+  playNextQuestion();
+};
+
 onMounted(() => {
   // Request microphone access on page load
   console.log("Requesting microphone access...");
@@ -471,7 +500,10 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        playNextQuestion();
+        // Only auto-play next question on desktop
+        if (isDesktop.value) {
+          playNextQuestion();
+        }
       };
     }
   });


### PR DESCRIPTION
# Problem
Previously, when a user clicked the BackArrow button in any game, it always navigated back to the `/game-zone` page with the Language Games tab selected by default even if the user had originally entered from Math Games.

This created a confusing experience, especially for users expecting to return to the correct category they came from.

# Solution
- Introduced sessionStorage to temporarily store the game category before navigating back. (Only applied in math games)
- On the /game-zone page, added a check on `onMounted()` to retrieve the category from sessionStorage and call `changeCurrentPage()` accordingly.
- The stored value is cleared from sessionStorage after use to prevent stale behavior.

# Updated Files
- All Math Game in `src/pages/GameZone/GameZoneList` (8 in total)
- GameZone.vue
