### PR TITLE
fix: 🐛 Change to partial match for user response and answer

### DIFF
--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -405,8 +405,11 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
       
-      const answers = question["A"].map((ans) => ans.toLowerCase());
-      if (answers.includes(finalTranscript.trim().toLowerCase())) {
+      if (
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/CarCounting.vue
+++ b/src/pages/GameZone/GameZoneList/CarCounting.vue
@@ -468,9 +468,8 @@ const toggleRecording = () => {
       console.log("Correct Answer:", randQueNum[numOfAudiosPlayed.value]);
 
       if (
-        finalTranscript.trim().toLowerCase() ===
-        answers[numOfAudiosPlayed.value]
-      ) {
+        finalTranscript.trim().toLowerCase().includes(answers[numOfAudiosPlayed.value].toLowerCase())
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -403,9 +403,9 @@ const toggleRecording = () => {
       console.log("Correct Answer:", question["A"]);
 
       if (
-        question["A"]
-          .map((str) => str.toLowerCase())
-          .includes(finalTranscript.trim().toLowerCase())
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
       ) {
         score.value++;
         console.log("Correct Answer!");

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -402,9 +402,9 @@ const toggleRecording = () => {
       console.log("Correct Answer:", question["A"]);
 
       if (
-        question["A"]
-          .map((str) => str.toLowerCase())
-          .includes(finalTranscript.trim().toLowerCase())
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
       ) {
         score.value++;
         console.log("Correct Answer!");

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -406,9 +406,9 @@ const toggleRecording = () => {
       console.log("Correct Answer:", question["A"]);
 
       if (
-        question["A"]
-          .map((str) => str.toLowerCase())
-          .includes(finalTranscript.trim().toLowerCase())
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
       ) {
         score.value++;
         console.log("Correct Answer!");

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -410,8 +410,11 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      const answers = question["A"].map((ans) => ans.toLowerCase());
-      if (answers.includes(finalTranscript.trim().toLowerCase())) {
+      if (
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -404,8 +404,11 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      const answers = question["A"].map((ans) => ans.toLowerCase());
-      if (answers.includes(finalTranscript.trim().toLowerCase())) {
+      if (
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -409,8 +409,11 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      const answers = question["A"].map((ans) => ans.toLowerCase());
-      if (answers.includes(finalTranscript.trim().toLowerCase())) {
+      if (
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/OddOneOut.vue
+++ b/src/pages/GameZone/GameZoneList/OddOneOut.vue
@@ -430,10 +430,10 @@ const toggleRecording = () => {
       console.log("Correct Answer:", question["A"]);
 
       if (
-        question["A"]
-          .map((str) => str.toLowerCase())
-          .includes(finalTranscript.trim().toLowerCase())
-      ) {
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -399,10 +399,10 @@ const toggleRecording = () => {
       console.log("Correct Answer:", question["A"]);
 
       if (
-        question["A"]
-          .map((str) => str.toLowerCase())
-          .includes(finalTranscript.trim().toLowerCase())
-      ) {
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -426,10 +426,10 @@ const toggleRecording = () => {
       console.log("Correct Answer:", question["A"]);
 
       if (
-        question["A"]
-          .map((str) => str.toLowerCase())
-          .includes(finalTranscript.trim().toLowerCase())
-      ) {
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -406,8 +406,11 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      const answers = question["A"].map((ans) => ans.toLowerCase());
-      if (answers.includes(finalTranscript.trim().toLowerCase())) {
+      if (
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -407,8 +407,11 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      const answers = question["A"].map((ans) => ans.toLowerCase());
-      if (answers.includes(finalTranscript.trim().toLowerCase())) {
+      if (
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -403,10 +403,10 @@ const toggleRecording = () => {
       console.log("Correct Answer:", question["A"]);
 
       if (
-        question["A"]
-          .map((str) => str.toLowerCase())
-          .includes(finalTranscript.trim().toLowerCase())
-      ) {
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/Vocab.vue
+++ b/src/pages/GameZone/GameZoneList/Vocab.vue
@@ -401,10 +401,10 @@ const toggleRecording = () => {
       console.log("Correct Answer:", question["A"]);
 
       if (
-        question["A"]
-          .map((str) => str.toLowerCase())
-          .includes(finalTranscript.trim().toLowerCase())
-      ) {
+        question["A"].some((answer) =>
+          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
+        )
+      ){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");


### PR DESCRIPTION
# Problem
Previously, the system handled answer comparison by checking for exact matches only. This led to correct answers being marked as incorrect if the user's speech-to-text transcript included additional words or punctuation—for example, responses like “It’s red” or “red.” were not recognized as correct matches for the expected answer “red”.

# Solution
Implemented partial matching by checking whether the correct answer is contained within the user's transcript. This makes the system more flexible in handling natural spoken responses without requiring an exact string match.

# Updated Files
Applied changes to all games except Spelling Bee, where exact letter-by-letter matching is still required to ensure accuracy.

# Additional Information
Further adjustment is needed for math-related games, as partial matching could lead to false positives. For example, a user saying "twenty-five" may be incorrectly accepted when the correct answer is "twenty". Future improvements may include more context-aware matching or stricter logic for numerical comparisons.