### PR TITLE
Refactor: Header Layout with Grid for Responsive Navbar and Logo Alignment

### DIFF
--- a/src/components/Header/Header.vue
+++ b/src/components/Header/Header.vue
@@ -1,7 +1,9 @@
 <template>
-    <header class="relative py-8">
+    <!-- Header height = 60px logo + 32px top offset (top-8) + 32px bottom padding = 124px. -->
+    <!-- Logo size is fixed to maintain a consistent UI across viewports. -->  
+    <header id="header-grid" class="relative h-[124px]">
         <!-- Logo Section -->
-        <div class="text-lg font-bold absolute left-4 top-8 z-10">
+        <div id="logo-item" class="text-lg font-bold absolute left-2 top-8 z-10">
             <RouterLink to="/home">
                 <img
                     :src="logoPath"
@@ -14,46 +16,46 @@
         </div>
 
         <!-- Hamburger Button for Mobile -->
-        <div v-if="isMobileView" class="absolute right-4 top-8 z-30">
+        <div id="nav-btn-item" v-if="isMobileView" class="absolute right-4 top-12 z-30">
             <button @click="toggleMenu" class="text-2xl">&#9776;</button>
         </div>
 
         <!-- Desktop Navigation Links -->
-        <nav v-if="!isMobileView" class="flex justify-center py-2">
-            <ul class="flex font-poppins font-semibold" 
+        <nav id="nav-links-grid" v-if="!isMobileView" class="justify-end py-2">
+            <ul id="router-links-grid" class="font-poppins font-semibold" 
                 :class="[
                     textColor ?? 'text-[#151e22]',
                     isTabletView ? 'space-x-2x text-sm' : 'space-x-4'
                 ]">
-                <li>
+                <li id="home-item">
                     <RouterLink
                         to="/home"
                         class="px-2 pb-2 hover:text-[#087bb4] hover:border-b-2 border-[#087bb4]"
                         >Home</RouterLink
                     >
                 </li>
-                <li>
+                <li id="about-item">
                     <RouterLink
                         to="/about-us"
                         class="px-2 pb-2 hover:text-[#087bb4] hover:border-b-2 border-[#087bb4]"
                         >About us</RouterLink
                     >
                 </li>
-                <li>
+                <li id="projects-item">
                     <RouterLink
                         to="/our-projects"
                         class="px-2 pb-2 hover:text-[#087bb4] hover:border-b-2 border-[#087bb4]"
                         >Our projects</RouterLink
                     >
                 </li>
-                <li>
+                <li id="impact-item">
                     <RouterLink
                         to="/impact"
                         class="px-2 pb-2 hover:text-[#087bb4] hover:border-b-2 border-[#087bb4]"
                         >Impact</RouterLink
                     >
                 </li>
-                <li>
+                <li id="games-item">
                     <RouterLink
                         to="/game-zone"
                         class="px-2 pb-2 hover:text-[#087bb4] hover:border-b-2 border-[#087bb4]"
@@ -218,3 +220,70 @@ onUnmounted(() => {
     document.body.style.overflow = '';
 });
 </script>
+
+<style>
+/* Default: Mobile view (max-width: 639px) */
+#header-grid {
+    display: grid;
+    grid-template-areas: 'logo . . . . rightmost';
+}
+
+#logo-item {
+    grid-column: 1 / span 5;
+}
+
+#logo-item img {
+    /* Prevent logo image from resizing to maintain a consistent UI */
+    height: 60px;
+    width: auto;
+    object-fit: contain;
+}
+
+#nav-btn-item {
+    grid-column: 6 / span 1;
+}
+
+/* Align nav links with logo */
+#router-links-grid > li {
+    align-self: center;
+}
+
+/* Medium and Large Devices (≥768px) */
+@media only screen and (min-width: 768px) {
+    #logo-item {
+        grid-column: 1 / span 5;
+    }
+
+    #nav-links-grid {
+        grid-column: 6 / span 1;
+        display: grid;
+        grid-template-areas: '. . . . .';
+    }
+
+    #router-links-grid {
+        grid-column: 1 / span 5;
+        display: grid;
+        grid-template-area: 'home about projects impact games';
+    }
+
+    #home-item {
+        grid-column: 1 / span 1;
+    }
+
+    #about-item {
+        grid-column: 2 / span 1;
+    }
+
+    #projects-item {
+        grid-column: 3 / span 1;
+    }
+
+    #impact-item {
+        grid-column: 4 / span 1;
+    }
+
+    #games-item {
+        grid-column: 5 / span 1;
+    }
+}
+</style>

--- a/src/pages/AboutUs/AboutUs.vue
+++ b/src/pages/AboutUs/AboutUs.vue
@@ -12,7 +12,7 @@ import CallToAction from "./CallToAction/CallToAction.vue";
 <template>
     <ScrollUpButton />
 
-    <div class="px-20 relative" ref="content">
+    <div class="px-16 relative" ref="content">
         <Header :logoPath="'/assets/images/header/header-logo-2.png'" />
         <Foundation />
         <Volunteers />

--- a/src/pages/GameZone/GameZone.vue
+++ b/src/pages/GameZone/GameZone.vue
@@ -27,7 +27,7 @@ onMounted(() => {
   <div
     class="relative bg-white h-full overflow-x-hidden flex flex-col justify-center"
   >
-    <div class="px-20">
+    <div class="px-16">
       <Header
         :textColor="'text-black'"
         :logoPath="'/assets/images/header/header-logo-2.png'"

--- a/src/pages/GameZone/GameZoneCard/GameZoneCard.vue
+++ b/src/pages/GameZone/GameZoneCard/GameZoneCard.vue
@@ -18,6 +18,7 @@ const props = defineProps({
         @click="$emit('selectGame', url)"
         class="w-full h-[320px] mobile:h-[160px] rounded-[16px] border-[5px] border-[#323232] shadow-2xl  p-5 relative flex justify-center items-center"
         :style="{ backgroundColor: bgColor, color: textColor ?? '#323232' }"
+        style="z-index:0"
     >
         <img
             :src="icon"

--- a/src/pages/Home/Home.vue
+++ b/src/pages/Home/Home.vue
@@ -55,7 +55,7 @@ onUnmounted(() => {
   <div 
     :class="[
       'relative', 
-      !isTablet && !isMobile ? 'px-20' : '',
+      !isTablet && !isMobile ? 'px-16' : '',
       isTablet ? 'px-10' : '',
       isMobile ? 'px-5' : ''
     ]" 

--- a/src/pages/Impact/Impact.vue
+++ b/src/pages/Impact/Impact.vue
@@ -12,7 +12,7 @@ import ImpactInAction from "./ImpactInAction/ImpactInAction.vue";
 <template>
     <ScrollUpButton />
 
-    <div class="px-20 relative" ref="content">
+    <div class="px-16 relative" ref="content">
         <Header :logoPath="'/assets/images/header/header-logo-2.png'" />
         <OurReach />
     </div>

--- a/src/pages/OurProjects/OurProjects.vue
+++ b/src/pages/OurProjects/OurProjects.vue
@@ -12,7 +12,7 @@ import Footer from "../../components/Footer/Footer.vue";
 
 <template>
     <ScrollUpButton />
-    <div class="px-20 relative" ref="content">
+    <div class="px-16 relative" ref="content">
         <Header :logoPath="'/assets/images/header/header-logo-2.png'" />
     </div>
 


### PR DESCRIPTION
## Problem 
- In desktop view, `<nav>` links overlapped the logo image in the header when resizing the browser between widths of `768–862px` and `1025–1057px`. 
- The `<nav>` links were not aligned with the logo. 
- On smaller viewports, the collapsible navbar overlapped with game zone cards. 

## Solution
- Replaced `flex` with a CSS `grid` layout in `Header.vue` and added media queries to improve responsiveness across screen widths and device types. 
- Recalculated the `<header>` height to align `<nav>` links with the logo. 
- Reduced desktop view page padding to `px-16` across nav-linked pages to better support the responsive grid layout and maintain a consistent UI during resizing. 
- Resolved game card titles overlapping with the mobile collapsible navbar in `GameZoneCard.vue` by setting `z-index:0`. 

## Updated Files
- `Header.vue` 
- `GameZoneCard.vue` 
- All linked pages in the navbar (`Home.vue`, `Impact.vue`, `AboutUs.vue`, `OurProjects.vue`, `GameZone.vue`) 

## Additional Information
- Base branch: `release/v2.0` 
- Sub-branch: `refactor/responsive-design` (first commit on this branch) 