### PR TITLE
hotfix: Updated map and added a school to list 🛠️

### DIFF
--- a/src/pages/Impact/CollaboratingSchools/Affiliates.vue
+++ b/src/pages/Impact/CollaboratingSchools/Affiliates.vue
@@ -31,8 +31,8 @@ const schools = [
         link: "https://asdb.az.gov/",
     },
     {
-        name: "Obra D. Tompkins High School",
-        link: "https://www.katyisd.org/tompkins",
+        name: "Vermont Association For The Blind And Visually Impaired",
+        link: "https://www.vabvi.org/",
     },
     {
         name: "HeZe Special Education Center (菏泽市特殊教育中心)",

--- a/src/pages/Impact/CollaboratingSchools/Map.vue
+++ b/src/pages/Impact/CollaboratingSchools/Map.vue
@@ -26,7 +26,7 @@ export default {
                 var location4 = [-89, 40];
                 var location5 = [-111.0937, 34.0489];
                 var location6 = [117.0208, 36.6683];
-                var location7 = [-95.3698, 29.7604];
+                var location7 = [-72.576, 44.2601];
                 var popupOffset = 25;
 
                 var marker1 = new tt.Marker().setLngLat(location1).addTo(map);
@@ -66,7 +66,9 @@ export default {
                 var popup7 = new tt.Popup({
                     offset: popupOffset,
                     closeButton: false,
-                }).setText("Obra D. Tompkins High School");
+                }).setText(
+                    "Vermont Association For The Blind And Visually Impaired"
+                );
 
                 marker1.setPopup(popup1);
                 marker2.setPopup(popup2);


### PR DESCRIPTION
## **Problem:**

The “Affiliated Schools” section of the Impact page was missing a newly affiliated institution, Vermont Association For The Blind And Visually Impaired, which had not yet been added to either the schools list or the map view.
Additionally, Obra D. Tompkins High School was mistakenly still shown on the map, even though it is no longer an active partner or relevant to the context.

## **Solution:**

Frontend Updates:
	•	Affiliates.vue
	•	Added Vermont Association For The Blind And Visually Impaired to the schools array with an official link.
	•	This makes it show up in the “Affiliated Schools” tab with the rest of the schools. 
	•	Removed map marker and popup for Obra D. Tompkins High School.
	•	Added a new map marker and popup for Vermont Association For The Blind And Visually Impaired using approximate location coordinates ([-72.5760, 44.2601]).
	•	Ensured the new marker displays correctly using TomTom’s Maps API and styling conventions already in place.

## **Impact & Dependencies:**
•	No backend changes or configuration adjustments required.
	•	No impact on authentication, user sessions, or stateful components.
	•	All updates are scoped to the Impact view and visual/interactive changes only.

## **Screenshot:**
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/1fde796f-5c32-42c8-ae3e-2b7d02797b08" />
