### PR TITLE
Fix: Modify partial matching data preprocessing to prevent false positives

### DIFF
--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -405,11 +405,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
       
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -402,11 +402,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ) {
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -401,11 +401,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ) {
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -405,11 +405,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ) {
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -410,11 +410,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -404,11 +404,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -409,11 +409,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/OddOneOut.vue
+++ b/src/pages/GameZone/GameZoneList/OddOneOut.vue
@@ -429,11 +429,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -398,11 +398,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -425,11 +425,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -407,11 +407,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -402,11 +402,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");

--- a/src/pages/GameZone/GameZoneList/Vocab.vue
+++ b/src/pages/GameZone/GameZoneList/Vocab.vue
@@ -400,11 +400,16 @@ const toggleRecording = () => {
       console.log("User Answer:", finalTranscript);
       console.log("Correct Answer:", question["A"]);
 
-      if (
-        question["A"].some((answer) =>
-          finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
-        )
-      ){
+      const userWords = finalTranscript
+      .toLowerCase()
+      .replace(/[.,!?]/g, "")
+      .split(/\s+/);
+
+      const correctAnswers = Array.isArray(question["A"])
+        ? question["A"].map((a) => a.toLowerCase())
+        : [question["A"].toLowerCase()];
+
+      if (userWords.some((word) => correctAnswers.includes(word))){
         score.value++;
         console.log("Correct Answer!");
         playSound("correctaudio.mp3");


### PR DESCRIPTION
# Problem
The current partial matching system for answer validation sometimes leads to **false positives**. For instance, if the correct answer is "seven" and the user says "seventeen", the system incorrectly marks it as correct because "seven" is part of "seventeen". This behavior **affects the accuracy of the game's response validation**.

# Solution
Implemented the following changes to the data preprocessing:
1. **Normalize and clean the user input**: The user's response (finalTranscript) is converted to lowercase using `.toLowerCase()` for case-insensitive comparison. Punctuation marks are removed with `.replace(/[.,!?]/g, "")`. Then, the response is split into individual words using `.split(/\s+/)` to handle multi-word responses effectively.
2. **Prepare the correct answers**: The correct answers from `question["A"]` are normalized by converting them to lowercase. If `question["A"]` contains multiple correct answers, each answer is converted to lowercase and stored in an array. If it's a single correct answer, it is also converted to lowercase and treated as an array for consistency.
3. **Compare the user's input with the correct answers**: Each word in the user's response is compared against the list of correct answers. We use `.some()` to check if any word from the user’s input matches any of the correct answers.


# Updated Files
- `.vue` for 7 language games (Spelling bee is not included since it needs exact letter-by-letter matching)
- `.vue` for 6 math games (Shape Shark and Car Counting not included)

