### PR TITLE
Disable the record button until the question has finished playing

### DIFF
--- a/src/Utilities/playAudio.js
+++ b/src/Utilities/playAudio.js
@@ -1,99 +1,101 @@
 export function playIntro(audioFile) {
-    // Play introduction audio
-    const introAudioPath = "/assets" + audioFile;
-    console.log("Playing introduction audio:", introAudioPath);
-    const audio = new Audio(introAudioPath);
-    audio.play();
+  // Play introduction audio
+  const introAudioPath = '/assets' + audioFile;
+  console.log('Playing introduction audio:', introAudioPath);
+  const audio = new Audio(introAudioPath);
+  audio.play();
 
-    return audio;
+  return audio;
 }
 
 export async function playQuestion(question) {
-    try {
-        const audioBlob = await getTTSAudio(question); // Wait for TTS to generate
-        if (!audioBlob) {
-            console.error("Audio generation failed.");
-            return;
-        }
-
-        const audioURL = URL.createObjectURL(audioBlob);
-        await playAudioPath(audioURL); // Ensure this function handles promises properly
-    } catch (error) {
-        console.error("Error in playQuestion:", error);
+  try {
+    const audioBlob = await getTTSAudio(question); // Wait for TTS to generate
+    if (!audioBlob) {
+      console.error('Audio generation failed.');
+      return;
     }
+
+    const audioURL = URL.createObjectURL(audioBlob);
+    await playAudioPath(audioURL); // Ensure this function handles promises properly
+  } catch (error) {
+    console.error('Error in playQuestion:', error);
+  }
 }
+
 export async function getTTSAudio(text) {
-    try {
-        const response = await fetch("/api/generate-tts", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ text }),
-        });
+  try {
+    const response = await fetch('/api/generate-tts', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text }),
+    });
 
-        if (!response.ok) {
-            throw new Error("Failed to generate TTS");
-        }
-
-        return await response.blob();
-    } catch (error) {
-        console.error("Error fetching TTS audio:", error);
-        return null;
+    if (!response.ok) {
+      throw new Error('Failed to generate TTS');
     }
+
+    return await response.blob();
+  } catch (error) {
+    console.error('Error fetching TTS audio:', error);
+    return null;
+  }
 }
 
 export function playSound(audioFile) {
-    // Play introduction audio
-    const introAudioPath = "/assets/generalAudio/" + audioFile;
-    console.log("Playing introduction audio:", introAudioPath);
-    const audio = new Audio(introAudioPath);
-    audio.play();
+  // Play introduction audio
+  const introAudioPath = '/assets/generalAudio/' + audioFile;
+  console.log('Playing introduction audio:', introAudioPath);
+  const audio = new Audio(introAudioPath);
+  audio.play();
 
-    return audio;
+  return audio;
 }
+
 let currentAudios = [];
+
 export function playAudioPath(path) {
-    return new Promise((resolve) => {
-        let audio = new Audio(path);
-        currentAudios.push(audio); // Track the audio in the array
-        audio.play()
-            .then(() => {
-                console.log("Audio playback started successfully.");
-                resolve();
-            })
-            .catch((err) => {
-                console.warn("⚠️ Playback blocked or failed:", err);
-                resolve();
-            });
+  return new Promise((resolve, reject) => {
+    let audio = new Audio(path);
+    currentAudios.push(audio);
 
-        // audio.onplay = () => {
-        //     this.isRecording = true;
-        // };
+    audio.onended = () => {
+      resolve();
+    };
 
-        // audio.onended = () => {
-        //     this.isRecording = false;
-        //     console.log("Audio ended.");
-        resolve();
-        // };
-    });
+    audio.onerror = (error) => {
+      reject(new Error('Audio playback failed: ' + error.message));
+    };
+
+    audio
+      .play()
+      .then(() => {
+        console.log('Audio playback started successfully.');
+      })
+      .catch((error) => {
+        console.warn('⚠️ Playback blocked or failed:', error);
+        reject(new Error('Playback blocked or failed: ' + error.message));
+      });
+  });
 }
 
 export function playScore(score) {
-    const scoreAudioPath = "/assets/generalAudio/" + score + "correct.mp3";
-    console.log("Playing Final score audio:", scoreAudioPath);
-    const audio = new Audio(scoreAudioPath);
-    audio.play();
+  const scoreAudioPath = '/assets/generalAudio/' + score + 'correct.mp3';
+  console.log('Playing Final score audio:', scoreAudioPath);
+  const audio = new Audio(scoreAudioPath);
+  audio.play();
 
-    return audio;
+  return audio;
 }
 
 export function stopAudios(audioList) {
-    audioList.forEach((audio) => {
-        if (audio instanceof HTMLAudioElement) {
-            audio.pause();
-            audio.currentTime = 0;
-        }
-    });
-    audioList.length = 0;
+  audioList.forEach((audio) => {
+    if (audio instanceof HTMLAudioElement) {
+      audio.pause();
+      audio.currentTime = 0;
+    }
+  });
+  audioList.length = 0;
 }

--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -159,7 +159,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -188,10 +188,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -227,7 +227,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -267,20 +267,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -295,7 +295,7 @@ const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const questionsDb = ref([]);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -325,23 +325,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -350,12 +350,12 @@ const recordButtonTitle = computed(() => {
 // 6. Lifecycle Hooks
 onMounted(() => {
   // Request microphone access on page load
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   // Check device type initially and set up listener for window resize
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -363,7 +363,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/animalAddition/additionintro.mp3");
+      const introAudio = playIntro('/animalAddition/additionintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -378,9 +378,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -412,14 +412,14 @@ const checkDeviceType = () => {
  * Generates addition questions from JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/additionDb.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/additionDb.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["AdditionGame"]["Questions"]["Easy"],
-        ...data["AdditionGame"]["Questions"]["Medium"],
-        ...data["AdditionGame"]["Questions"]["Hard"],
+        ...data['AdditionGame']['Questions']['Easy'],
+        ...data['AdditionGame']['Questions']['Medium'],
+        ...data['AdditionGame']['Questions']['Hard'],
       ];
 
       // Only need 5 random questions
@@ -430,21 +430,24 @@ const generateQuestions = () => {
         }
       }
       questionsDb.value = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb.value);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -461,35 +464,35 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
 
       const question = questionsDb.value[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
-      
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
+
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        console.log("Correct Answer is: ", question["A"]);
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        console.log('Correct Answer is: ', question['A']);
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -503,9 +506,8 @@ const toggleRecording = () => {
 
       // Reset transcription for next question
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
@@ -513,7 +515,7 @@ const toggleRecording = () => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -527,11 +529,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -548,7 +550,7 @@ const repeatQuestion = () => {
 
     // logging message for repeating question
     console.log(
-      "Repeating question for Animal Addition game - Question #" +
+      'Repeating question for Animal Addition game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -560,9 +562,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -571,7 +573,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/CarCounting.vue
+++ b/src/pages/GameZone/GameZoneList/CarCounting.vue
@@ -156,7 +156,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -185,10 +185,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -218,7 +218,7 @@
                   :title="repeatButtonTitle"
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -258,20 +258,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -286,7 +286,7 @@ const answers = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 const isPlaying = ref(false);
 
 // UI control states
@@ -306,34 +306,34 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
   isButtonDisabled.value || isPlaying.value
-    ? "opacity-50 cursor-not-allowed"
-    : "",
+    ? 'opacity-50 cursor-not-allowed'
+    : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value || isPlaying.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 const repeatButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
-  if (isPlaying.value) return "Please wait while the question is playing";
+    return 'Please wait until the introduction finishes';
+  if (isPlaying.value) return 'Please wait while the question is playing';
   if (isButtonCooldown.value)
-    return "Please wait before repeating the question again";
-  return "Repeat the current question";
+    return 'Please wait before repeating the question again';
+  return 'Repeat the current question';
 });
 
 // 5. Watch/WatchEffect
@@ -341,11 +341,11 @@ const repeatButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -353,7 +353,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/carCounting/carCountIntro.mp3");
+      const introAudio = playIntro('/carCounting/carCountIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -368,9 +368,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -402,37 +402,37 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates random number of cars as Questions
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 5) + 1;
     if (!randQueNum.includes(num)) {
       randQueNum.push(num);
       const answerMap = {
-        1: "one",
-        2: "two",
-        3: "three",
-        4: "four",
-        5: "five",
+        1: 'one',
+        2: 'two',
+        3: 'three',
+        4: 'four',
+        5: 'five',
       };
       answers.push(answerMap[num]);
     }
   }
-  console.log("Random Numbers: ", randQueNum);
-  console.log("Answers: ", answers);
+  console.log('Random Numbers: ', randQueNum);
+  console.log('Answers: ', answers);
 };
 
 /**
@@ -440,6 +440,7 @@ const generateQuestions = () => {
  */
 const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && !isPlaying.value) {
+    isButtonCooldown.value = true;
     isPlaying.value = true;
 
     // Stop all current audios
@@ -448,17 +449,17 @@ const playNextQuestion = async () => {
 
     const audiosToPlay = [];
 
-    playQuestion("Question Number " + (numOfAudiosPlayed.value + 1));
+    await playQuestion('Question Number ' + numOfAudiosPlayed.value);
 
     // Add the car passing by audios
     for (let i = 0; i < randQueNum[numOfAudiosPlayed.value]; i++) {
-      audiosToPlay.push("/assets/carCounting/carpassby.mp3");
+      audiosToPlay.push('/assets/carCounting/carpassby.mp3');
     }
 
     // Play all car audios in sequence
     for (const audioSrc of audiosToPlay) {
       await new Promise((resolve) => {
-        console.log("Playing - " + audioSrc);
+        console.log('Playing - ' + audioSrc);
         const audio = new Audio(audioSrc);
         audio.play();
         audio.onended = resolve;
@@ -467,9 +468,10 @@ const playNextQuestion = async () => {
     }
 
     // Add the final audio
-    playQuestion("How many cars did you hear?");
+    await playQuestion('How many cars did you hear?');
 
     isPlaying.value = false;
+    isButtonCooldown.value = false;
   }
 };
 
@@ -485,32 +487,37 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      playSound("ding-sound.mp3");
+      playSound('ding-sound.mp3');
 
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       // Get the final transcript
       const finalTranscript = transcription.value;
 
       // Process the answer
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", randQueNum[numOfAudiosPlayed.value]);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', randQueNum[numOfAudiosPlayed.value]);
 
-      const cleanedInput = finalTranscript.trim().toLowerCase().replace(/[^\w\s]/g, ''); // removes punctuation
-      if (cleanedInput.includes(answers[numOfAudiosPlayed.value].toLowerCase())) {
+      const cleanedInput = finalTranscript
+        .trim()
+        .toLowerCase()
+        .replace(/[^\w\s]/g, ''); // removes punctuation
+      if (
+        cleanedInput.includes(answers[numOfAudiosPlayed.value].toLowerCase())
+      ) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
+        console.log('Wrong Answer!');
         const incorectAudio =
-          "The correct answer is " + answers[numOfAudiosPlayed.value];
-        playSound("incorrectaudio.mp3");
+          'The correct answer is ' + answers[numOfAudiosPlayed.value];
+        playSound('incorrectaudio.mp3');
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -523,16 +530,15 @@ const toggleRecording = () => {
 
       // Reset transcription for next question
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -555,7 +561,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Car Counting game - Question #" +
+      'Repeating question for Car Counting game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -566,11 +572,11 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 4000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isPlaying.value) {
-    console.log("Cannot repeat question while audio is playing");
+    console.log('Cannot repeat question while audio is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -579,7 +585,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -155,7 +155,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -184,10 +184,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -223,7 +223,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -264,20 +264,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -292,7 +292,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -322,32 +322,32 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -355,7 +355,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/colorGame/colorIntro.mp3");
+      const introAudio = playIntro('/colorGame/colorIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -370,9 +370,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -404,7 +404,7 @@ const checkDeviceType = () => {
  * Generates color recognition questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -413,25 +413,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/crazyColorsDB.json")
+  fetch('/assets/questionsDb/crazyColorsDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["ColorQuizGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['ColorQuizGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["ColorQuizGame"]["Questions"]["Easy"];
+      questionsDb = data['ColorQuizGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -448,34 +451,34 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-  .toLowerCase()
-  .replace(/[^a-z0-9\s]/gi, "") // removes everything except letters, numbers, and spaces
-  .split(/\s+/)
-  .filter(Boolean); // removes empty strings
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/gi, '') // removes everything except letters, numbers, and spaces
+        .split(/\s+/)
+        .filter(Boolean); // removes empty strings
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -487,9 +490,8 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
@@ -497,7 +499,7 @@ const toggleRecording = () => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -511,13 +513,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -532,7 +534,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Color Game - Question #" +
+      'Repeating question for Color Game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -543,9 +545,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -554,7 +556,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -155,7 +155,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -184,10 +184,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -223,7 +223,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -263,20 +263,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -291,7 +291,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -321,23 +321,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -346,12 +346,12 @@ const recordButtonTitle = computed(() => {
 // 6. Lifecycle Hooks
 onMounted(() => {
   // Request microphone access on page load
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   // Check device type initially and set up listener for window resize
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   // Generate questions
   generateQuestions();
@@ -360,7 +360,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/definitionDetective/definitionIntro.mp3");
+      const introAudio = playIntro('/definitionDetective/definitionIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -375,9 +375,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -409,7 +409,7 @@ const checkDeviceType = () => {
  * Generates multiplication questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -418,28 +418,31 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/definitionDetectiveDB.json")
+  fetch('/assets/questionsDb/definitionDetectiveDB.json')
     .then((response) => response.json())
     .then((data) => {
       console.log(
-        "Questions:",
-        data["DefinitionDetectiveGame"]["Questions"]["Easy"]
+        'Questions:',
+        data['DefinitionDetectiveGame']['Questions']['Easy']
       );
       // Process the questions data as needed
-      questionsDb = data["DefinitionDetectiveGame"]["Questions"]["Easy"];
+      questionsDb = data['DefinitionDetectiveGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -457,34 +460,34 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       // Get the final transcript
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -498,9 +501,8 @@ const toggleRecording = () => {
 
       // Reset transcription for next question
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
@@ -508,7 +510,7 @@ const toggleRecording = () => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -522,11 +524,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -543,7 +545,7 @@ const repeatQuestion = () => {
 
     // logging message for repeating question
     console.log(
-      "Repeating question for Definition Detective game - Question #" +
+      'Repeating question for Definition Detective game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -555,9 +557,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3500);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -566,7 +568,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -154,7 +154,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -182,10 +182,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -221,7 +221,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -261,20 +261,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -289,7 +289,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -319,23 +319,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -343,11 +343,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -355,7 +355,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/divisionduel/divintro.mp3");
+      const introAudio = playIntro('/divisionduel/divintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -370,9 +370,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -404,14 +404,14 @@ const checkDeviceType = () => {
  * Generates division questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/divisionDb.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/divisionDb.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["DivisionGame"]["Questions"]["Easy"],
-        ...data["DivisionGame"]["Questions"]["Medium"],
-        ...data["DivisionGame"]["Questions"]["Hard"],
+        ...data['DivisionGame']['Questions']['Easy'],
+        ...data['DivisionGame']['Questions']['Medium'],
+        ...data['DivisionGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -423,21 +423,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -454,32 +457,32 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -491,16 +494,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -514,13 +516,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -535,7 +537,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Division Duel game - Question #" +
+      'Repeating question for Division Duel game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -546,9 +548,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3500);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -557,7 +559,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -157,7 +157,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -186,10 +186,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -225,7 +225,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -265,20 +265,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -293,7 +293,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -323,23 +323,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -347,11 +347,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -359,7 +359,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/fruitFrenzy/fruitIntro.mp3");
+      const introAudio = playIntro('/fruitFrenzy/fruitIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -374,9 +374,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -408,14 +408,14 @@ const checkDeviceType = () => {
  * Generates fruit counting questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/fruitFrenzy.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/fruitFrenzy.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["FruitFrenzy"]["Questions"]["Easy"],
-        ...data["FruitFrenzy"]["Questions"]["Medium"],
-        ...data["FruitFrenzy"]["Questions"]["Hard"],
+        ...data['FruitFrenzy']['Questions']['Easy'],
+        ...data['FruitFrenzy']['Questions']['Medium'],
+        ...data['FruitFrenzy']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -427,21 +427,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -458,38 +461,37 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
         }, 1000);
-
       }
 
       stopListening();
@@ -497,16 +499,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -520,13 +521,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -541,7 +542,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Fruit Frenzy game - Question #" +
+      'Repeating question for Fruit Frenzy game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -552,9 +553,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -563,7 +564,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -154,7 +154,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -183,10 +183,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -222,7 +222,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -262,20 +262,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -290,7 +290,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -320,23 +320,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -344,11 +344,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -356,7 +356,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/monkeyMadness/monkeyintro.mp3");
+      const introAudio = playIntro('/monkeyMadness/monkeyintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -371,9 +371,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -405,14 +405,14 @@ const checkDeviceType = () => {
  * Generates monkey madness questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/monkeyMadnessDB.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/monkeyMadnessDB.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["MonkeyMadnessGame"]["Questions"]["Easy"],
-        ...data["MonkeyMadnessGame"]["Questions"]["Medium"],
-        ...data["MonkeyMadnessGame"]["Questions"]["Hard"],
+        ...data['MonkeyMadnessGame']['Questions']['Easy'],
+        ...data['MonkeyMadnessGame']['Questions']['Medium'],
+        ...data['MonkeyMadnessGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -424,21 +424,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -455,32 +458,32 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -492,16 +495,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -515,13 +517,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -536,7 +538,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Monkey Madness game - Question #" +
+      'Repeating question for Monkey Madness game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -547,9 +549,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -558,7 +560,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -156,7 +156,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -185,10 +185,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -224,7 +224,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -264,20 +264,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -292,7 +292,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -322,23 +322,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -346,11 +346,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -359,7 +359,7 @@ onMounted(() => {
     if (newVal) {
       isIntroPlaying.value = true;
       const introAudio = playIntro(
-        "/multiplicationmadness/multiplicationintro.mp3"
+        '/multiplicationmadness/multiplicationintro.mp3'
       );
       currentAudios.push(introAudio);
       introAudio.onended = () => {
@@ -375,9 +375,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -409,14 +409,14 @@ const checkDeviceType = () => {
  * Generates multiplication questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/multiplication.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/multiplication.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["MultiplicationGame"]["Questions"]["Easy"],
-        ...data["MultiplicationGame"]["Questions"]["Medium"],
-        ...data["MultiplicationGame"]["Questions"]["Hard"],
+        ...data['MultiplicationGame']['Questions']['Easy'],
+        ...data['MultiplicationGame']['Questions']['Medium'],
+        ...data['MultiplicationGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -428,21 +428,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -459,38 +462,37 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
         }, 1000);
-
       }
 
       stopListening();
@@ -498,16 +500,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -521,13 +522,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -542,7 +543,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Multiplication Madness game - Question #" +
+      'Repeating question for Multiplication Madness game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -553,9 +554,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -564,7 +565,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/OddOneOut.vue
+++ b/src/pages/GameZone/GameZoneList/OddOneOut.vue
@@ -157,7 +157,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -186,10 +186,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -225,7 +225,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -265,20 +265,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -293,7 +293,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -323,23 +323,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -347,11 +347,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -359,7 +359,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/oddoneout/oddoneoutintro.mp3");
+      const introAudio = playIntro('/oddoneout/oddoneoutintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -374,9 +374,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -408,7 +408,7 @@ const checkDeviceType = () => {
  * Generates odd one out questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -417,25 +417,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/oddOneOutDB.json")
+  fetch('/assets/questionsDb/oddOneOutDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["OddOneOutGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['OddOneOutGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["OddOneOutGame"]["Questions"]["Easy"];
+      questionsDb = data['OddOneOutGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -451,7 +454,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Odd One Out game - Question #" +
+      'Repeating question for Odd One Out game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -462,9 +465,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -481,38 +484,37 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
         }, 1000);
-
       }
 
       stopListening();
@@ -520,16 +522,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -543,11 +544,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -555,7 +556,7 @@ const goBack = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -156,7 +156,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -185,10 +185,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -224,7 +224,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -264,20 +264,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -292,7 +292,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -322,23 +322,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait before repeating the question again";
-  return "Record your answer";
+    return 'Please wait before repeating the question again';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -346,11 +346,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -358,7 +358,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/partOfSpeech/partofspeechintro.mp3");
+      const introAudio = playIntro('/partOfSpeech/partofspeechintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -373,9 +373,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -407,7 +407,7 @@ const checkDeviceType = () => {
  * Generates part of speech questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -416,25 +416,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/partOfSpeechDB.json")
+  fetch('/assets/questionsDb/partOfSpeechDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["PartOfSpeechGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['PartOfSpeechGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["PartOfSpeechGame"]["Questions"]["Easy"];
+      questionsDb = data['PartOfSpeechGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -451,33 +454,33 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -489,16 +492,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -512,11 +514,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -531,7 +533,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Part of Speech game - Question #" +
+      'Repeating question for Part of Speech game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -542,9 +544,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 4000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -553,7 +555,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -157,7 +157,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -186,10 +186,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -225,7 +225,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -265,20 +265,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -293,7 +293,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -323,24 +323,24 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "", // Apply cooldown/intro disable class
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '', // Apply cooldown/intro disable class
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
     // Check cooldown for title
-    return "Please wait before repeating the question again";
-  return "Record your answer";
+    return 'Please wait before repeating the question again';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -348,11 +348,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -360,7 +360,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/polarpairing/oppintro.mp3");
+      const introAudio = playIntro('/polarpairing/oppintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -375,9 +375,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -409,7 +409,7 @@ const checkDeviceType = () => {
  * Generates polar pairing questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -418,25 +418,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/polarPairingDB.json")
+  fetch('/assets/questionsDb/polarPairingDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["PolarPairingGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['PolarPairingGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["PolarPairingGame"]["Questions"]["Easy"];
+      questionsDb = data['PolarPairingGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -452,7 +455,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Polar Pairing game - Question #" +
+      'Repeating question for Polar Pairing game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -463,9 +466,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -482,36 +485,36 @@ const toggleRecording = () => {
     }, false);
   } else {
     isButtonCooldown.value = true;
-    console.log("Processing recording...");
+    console.log('Processing recording...');
     stopListening();
     isRecording.value = false;
 
     const finalTranscript = transcription.value;
 
     if (currentQuestion.value) {
-      console.log("Question is: ", currentQuestion.value["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", currentQuestion.value["A"]);
+      console.log('Question is: ', currentQuestion.value['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', currentQuestion.value['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(currentQuestion.value['A'])
+        ? currentQuestion.value['A'].map((a) => a.toLowerCase())
+        : [currentQuestion.value['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
+        console.log('Wrong Answer!');
         const incorrectAudio =
-          "The correct answer is " + currentQuestion.value["A"][0];
-        playSound("incorrectaudio.mp3");
-        
+          'The correct answer is ' + currentQuestion.value['A'][0];
+        playSound('incorrectaudio.mp3');
+
         setTimeout(() => {
           currentAudios.push(playQuestion(incorrectAudio));
         }, 1000);
@@ -521,16 +524,15 @@ const toggleRecording = () => {
     numOfAudiosPlayed.value++;
 
     setTimeout(() => {
-      transcription.value = "";
+      transcription.value = '';
       setTimeout(() => {
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped. Cooldown ended.");
+        console.log('Recording processed and stopped. Cooldown ended.');
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 500);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 1000);
@@ -544,11 +546,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -557,7 +559,7 @@ const goBack = () => {
  */
 const startFirstQuestion = () => {
   if (isIntroPlaying.value) return;
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -156,7 +156,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -185,10 +185,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -224,7 +224,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -264,20 +264,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -292,7 +292,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -322,23 +322,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -346,11 +346,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -358,7 +358,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/shapeSharks/shapeintro.mp3");
+      const introAudio = playIntro('/shapeSharks/shapeintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -373,9 +373,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -407,27 +407,27 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates shape questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/shapeSharkDB.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/shapeSharkDB.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["ShapeSharkGame"]["Questions"]["Easy"],
-        ...data["ShapeSharkGame"]["Questions"]["Medium"],
-        ...data["ShapeSharkGame"]["Questions"]["Hard"],
+        ...data['ShapeSharkGame']['Questions']['Easy'],
+        ...data['ShapeSharkGame']['Questions']['Medium'],
+        ...data['ShapeSharkGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -439,21 +439,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -470,29 +473,29 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       if (currentQuestion.value) {
-        console.log("Question is: ", currentQuestion.value["Q"]);
-        console.log("User Answer:", finalTranscript);
-        console.log("Correct Answer:", currentQuestion.value["A"]);
+        console.log('Question is: ', currentQuestion.value['Q']);
+        console.log('User Answer:', finalTranscript);
+        console.log('Correct Answer:', currentQuestion.value['A']);
 
         if (
-          currentQuestion.value["A"].some((answer) =>
+          currentQuestion.value['A'].some((answer) =>
             finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
           )
         ) {
           score.value++;
-          console.log("Correct Answer!");
-          playSound("correctaudio.mp3");
+          console.log('Correct Answer!');
+          playSound('correctaudio.mp3');
         } else {
-          console.log("Wrong Answer!");
+          console.log('Wrong Answer!');
 
           const incorrectAudio =
-            "The correct answer is " + currentQuestion.value["A"][0];
-          playSound("incorrectaudio.mp3");
+            'The correct answer is ' + currentQuestion.value['A'][0];
+          playSound('incorrectaudio.mp3');
 
           setTimeout(() => {
             currentAudios.push(playQuestion(incorrectAudio));
@@ -505,16 +508,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -536,7 +538,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Shape Shark game - Question #" +
+      'Repeating question for Shape Shark game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -547,9 +549,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -558,7 +560,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/SpellingBee.vue
+++ b/src/pages/GameZone/GameZoneList/SpellingBee.vue
@@ -164,7 +164,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -193,10 +193,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -232,7 +232,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -271,20 +271,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -299,7 +299,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 const isListening = ref(false);
 
 // UI control states
@@ -330,23 +330,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -356,9 +356,9 @@ const recordButtonTitle = computed(() => {
 onMounted(() => {
   checkDeviceType();
 
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   generateQuestions();
@@ -367,7 +367,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/spellingBee/spellingintro.mp3");
+      const introAudio = playIntro('/spellingBee/spellingintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -382,9 +382,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -416,18 +416,18 @@ const checkDeviceType = () => {
  * Function to handle back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates spelling questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 15);
@@ -436,25 +436,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/spellingBeeDB.json")
+  fetch('/assets/questionsDb/spellingBeeDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["SpellingBeeGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['SpellingBeeGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["SpellingBeeGame"]["Questions"]["Easy"];
+      questionsDb = data['SpellingBeeGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -472,28 +475,28 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       if (currentQuestion.value) {
-        console.log("Question is: ", currentQuestion.value["Q"]);
-        console.log("User Answer:", finalTranscript);
-        console.log("Correct Answer:", currentQuestion.value["A"]);
+        console.log('Question is: ', currentQuestion.value['Q']);
+        console.log('User Answer:', finalTranscript);
+        console.log('Correct Answer:', currentQuestion.value['A']);
 
         if (
-          currentQuestion.value["A"].some((answer) =>
+          currentQuestion.value['A'].some((answer) =>
             finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
           )
         ) {
           score.value++;
-          console.log("Correct Answer!");
-          playSound("correctaudio.mp3");
+          console.log('Correct Answer!');
+          playSound('correctaudio.mp3');
         } else {
-          console.log("Wrong Answer!");
+          console.log('Wrong Answer!');
           const incorrectAudio =
-            "The correct answer is " + currentQuestion.value["A"][0];
-          playSound("incorrectaudio.mp3");
+            'The correct answer is ' + currentQuestion.value['A'][0];
+          playSound('incorrectaudio.mp3');
 
           setTimeout(() => {
             currentAudios.push(playQuestion(incorrectAudio));
@@ -507,16 +510,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -539,7 +541,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Spelling Bee game - Question #" +
+      'Repeating question for Spelling Bee game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -550,9 +552,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -561,7 +563,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -156,7 +156,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -185,10 +185,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -224,7 +224,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -264,20 +264,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -292,7 +292,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -322,23 +322,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -346,11 +346,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -358,7 +358,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/subtractionSafari/subtractionintro.mp3");
+      const introAudio = playIntro('/subtractionSafari/subtractionintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -373,9 +373,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -407,27 +407,27 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates subtraction questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/subtractionDB.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/subtractionDB.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["SubtractionGame"]["Questions"]["Easy"],
-        ...data["SubtractionGame"]["Questions"]["Medium"],
-        ...data["SubtractionGame"]["Questions"]["Hard"],
+        ...data['SubtractionGame']['Questions']['Easy'],
+        ...data['SubtractionGame']['Questions']['Medium'],
+        ...data['SubtractionGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -439,21 +439,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -470,38 +473,37 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
         }, 1000);
-
       }
 
       stopListening();
@@ -509,16 +511,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -540,7 +541,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Subtraction Safari game - Question #" +
+      'Repeating question for Subtraction Safari game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -551,9 +552,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -562,7 +563,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -156,7 +156,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -185,10 +185,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -224,7 +224,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -264,20 +264,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -292,7 +292,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -322,23 +322,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -346,11 +346,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -358,7 +358,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/syllableSorting/syllableIntro.mp3");
+      const introAudio = playIntro('/syllableSorting/syllableIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -373,9 +373,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -407,18 +407,18 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates syllable questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -427,28 +427,31 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/SyllableGameDB.json")
+  fetch('/assets/questionsDb/SyllableGameDB.json')
     .then((response) => response.json())
     .then((data) => {
       console.log(
-        "Questions:",
-        data["SyllableCountingGame"]["Questions"]["Easy"]
+        'Questions:',
+        data['SyllableCountingGame']['Questions']['Easy']
       );
       // Process the questions data as needed
-      questionsDb = data["SyllableCountingGame"]["Questions"]["Easy"];
+      questionsDb = data['SyllableCountingGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -465,33 +468,33 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -504,9 +507,8 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
@@ -514,7 +516,7 @@ const toggleRecording = () => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -536,7 +538,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Syllable Sorting game - Question #" +
+      'Repeating question for Syllable Sorting game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -547,9 +549,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -558,7 +560,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };

--- a/src/pages/GameZone/GameZoneList/Vocab.vue
+++ b/src/pages/GameZone/GameZoneList/Vocab.vue
@@ -157,7 +157,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -186,10 +186,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -225,7 +225,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -265,20 +265,20 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -293,7 +293,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -323,23 +323,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -347,11 +347,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -359,7 +359,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/vocabVortex/vortexintro.mp3");
+      const introAudio = playIntro('/vocabVortex/vortexintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -374,9 +374,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -408,18 +408,18 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates vocabulary questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 15);
@@ -428,25 +428,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/VocabVortexDB.json")
+  fetch('/assets/questionsDb/VocabVortexDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["VocabVortexGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['VocabVortexGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["VocabVortexGame"]["Questions"]["Easy"];
+      questionsDb = data['VocabVortexGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -463,33 +466,33 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -501,16 +504,16 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
+        transcription.value = '';
         isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -532,7 +535,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Vocabulary Vortex game - Question #" +
+      'Repeating question for Vocabulary Vortex game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -543,9 +546,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -554,7 +557,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };


### PR DESCRIPTION
# Reference
Issues
- https://github.com/Crustaly/audemywebsite/issues/95
- https://github.com/Crustaly/audemywebsite/issues/98

https://github.com/Crustaly/audemywebsite/pull/125 (Previously opened PR)

# Describe your changes
- Made sure the record button is only enabled after the question has been fully given to the user. The `playAudioPath` method in the `playAudio` file has been updated to resolve only after the audio/question finishes playing.
- This PR also addresses this [issue](https://github.com/Crustaly/audemywebsite/issues/98)