### PR TITLE
Disable the record button until the question has finished playing

### DIFF
--- a/src/Utilities/playAudio.js
+++ b/src/Utilities/playAudio.js
@@ -1,99 +1,99 @@
 export function playIntro(audioFile) {
-    // Play introduction audio
-    const introAudioPath = "/assets" + audioFile;
-    console.log("Playing introduction audio:", introAudioPath);
-    const audio = new Audio(introAudioPath);
-    audio.play();
+  // Play introduction audio
+  const introAudioPath = '/assets' + audioFile;
+  console.log('Playing introduction audio:', introAudioPath);
+  const audio = new Audio(introAudioPath);
+  audio.play();
 
-    return audio;
+  return audio;
 }
 
 export async function playQuestion(question) {
-    try {
-        const audioBlob = await getTTSAudio(question); // Wait for TTS to generate
-        if (!audioBlob) {
-            console.error("Audio generation failed.");
-            return;
-        }
-
-        const audioURL = URL.createObjectURL(audioBlob);
-        await playAudioPath(audioURL); // Ensure this function handles promises properly
-    } catch (error) {
-        console.error("Error in playQuestion:", error);
+  try {
+    const audioBlob = await getTTSAudio(question); // Wait for TTS to generate
+    if (!audioBlob) {
+      console.error('Audio generation failed.');
+      return;
     }
+
+    const audioURL = URL.createObjectURL(audioBlob);
+    await playAudioPath(audioURL); // Ensure this function handles promises properly
+  } catch (error) {
+    console.error('Error in playQuestion:', error);
+  }
 }
 export async function getTTSAudio(text) {
-    try {
-        const response = await fetch("/api/generate-tts", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ text }),
-        });
+  try {
+    const response = await fetch('/api/generate-tts', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text }),
+    });
 
-        if (!response.ok) {
-            throw new Error("Failed to generate TTS");
-        }
-
-        return await response.blob();
-    } catch (error) {
-        console.error("Error fetching TTS audio:", error);
-        return null;
+    if (!response.ok) {
+      throw new Error('Failed to generate TTS');
     }
+
+    return await response.blob();
+  } catch (error) {
+    console.error('Error fetching TTS audio:', error);
+    return null;
+  }
 }
 
 export function playSound(audioFile) {
-    // Play introduction audio
-    const introAudioPath = "/assets/generalAudio/" + audioFile;
-    console.log("Playing introduction audio:", introAudioPath);
-    const audio = new Audio(introAudioPath);
-    audio.play();
+  // Play introduction audio
+  const introAudioPath = '/assets/generalAudio/' + audioFile;
+  console.log('Playing introduction audio:', introAudioPath);
+  const audio = new Audio(introAudioPath);
+  audio.play();
 
-    return audio;
+  return audio;
 }
 let currentAudios = [];
+
 export function playAudioPath(path) {
-    return new Promise((resolve) => {
-        let audio = new Audio(path);
-        currentAudios.push(audio); // Track the audio in the array
-        audio.play()
-            .then(() => {
-                console.log("Audio playback started successfully.");
-                resolve();
-            })
-            .catch((err) => {
-                console.warn("⚠️ Playback blocked or failed:", err);
-                resolve();
-            });
+  return new Promise((resolve, reject) => {
+    let audio = new Audio(path);
+    currentAudios.push(audio);
 
-        // audio.onplay = () => {
-        //     this.isRecording = true;
-        // };
+    audio.onended = () => {
+      resolve();
+    };
 
-        // audio.onended = () => {
-        //     this.isRecording = false;
-        //     console.log("Audio ended.");
-        resolve();
-        // };
-    });
+    audio.onerror = (error) => {
+      reject(new Error('Audio playback failed: ' + error.message));
+    };
+
+    audio
+      .play()
+      .then(() => {
+        console.log('Audio playback started successfully.');
+      })
+      .catch((error) => {
+        console.warn('⚠️ Playback blocked or failed:', error);
+        reject(new Error('Playback blocked or failed: ' + error.message));
+      });
+  });
 }
 
 export function playScore(score) {
-    const scoreAudioPath = "/assets/generalAudio/" + score + "correct.mp3";
-    console.log("Playing Final score audio:", scoreAudioPath);
-    const audio = new Audio(scoreAudioPath);
-    audio.play();
+  const scoreAudioPath = '/assets/generalAudio/' + score + 'correct.mp3';
+  console.log('Playing Final score audio:', scoreAudioPath);
+  const audio = new Audio(scoreAudioPath);
+  audio.play();
 
-    return audio;
+  return audio;
 }
 
 export function stopAudios(audioList) {
-    audioList.forEach((audio) => {
-        if (audio instanceof HTMLAudioElement) {
-            audio.pause();
-            audio.currentTime = 0;
-        }
-    });
-    audioList.length = 0;
+  audioList.forEach((audio) => {
+    if (audio instanceof HTMLAudioElement) {
+      audio.pause();
+      audio.currentTime = 0;
+    }
+  });
+  audioList.length = 0;
 }

--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -165,7 +165,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -194,10 +194,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -233,7 +233,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -273,21 +273,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -302,7 +302,7 @@ const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const questionsDb = ref([]);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -332,23 +332,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -357,12 +357,12 @@ const recordButtonTitle = computed(() => {
 // 6. Lifecycle Hooks
 onMounted(() => {
   // Request microphone access on page load
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   // Check device type initially and set up listener for window resize
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -370,7 +370,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/animalAddition/additionintro.mp3");
+      const introAudio = playIntro('/animalAddition/additionintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -385,9 +385,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -419,14 +419,14 @@ const checkDeviceType = () => {
  * Generates addition questions from JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/additionDb.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/additionDb.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["AdditionGame"]["Questions"]["Easy"],
-        ...data["AdditionGame"]["Questions"]["Medium"],
-        ...data["AdditionGame"]["Questions"]["Hard"],
+        ...data['AdditionGame']['Questions']['Easy'],
+        ...data['AdditionGame']['Questions']['Medium'],
+        ...data['AdditionGame']['Questions']['Hard'],
       ];
 
       // Only need 5 random questions
@@ -437,21 +437,24 @@ const generateQuestions = () => {
         }
       }
       questionsDb.value = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb.value);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -468,35 +471,35 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
 
       const question = questionsDb.value[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
-      
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
+
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        console.log("Correct Answer is: ", question["A"]);
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        console.log('Correct Answer is: ', question['A']);
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -510,9 +513,8 @@ const toggleRecording = () => {
 
       // Reset transcription for next question
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
@@ -520,7 +522,7 @@ const toggleRecording = () => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -534,11 +536,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -555,7 +557,7 @@ const repeatQuestion = () => {
 
     // logging message for repeating question
     console.log(
-      "Repeating question for Animal Addition game - Question #" +
+      'Repeating question for Animal Addition game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -567,9 +569,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -578,7 +580,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -586,12 +588,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/CarCounting.vue
+++ b/src/pages/GameZone/GameZoneList/CarCounting.vue
@@ -162,7 +162,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -191,10 +191,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -224,7 +224,7 @@
                   :title="repeatButtonTitle"
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -264,21 +264,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -293,7 +293,7 @@ const answers = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 const isPlaying = ref(false);
 
 // UI control states
@@ -313,34 +313,34 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
   isButtonDisabled.value || isPlaying.value
-    ? "opacity-50 cursor-not-allowed"
-    : "",
+    ? 'opacity-50 cursor-not-allowed'
+    : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value || isPlaying.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 const repeatButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
-  if (isPlaying.value) return "Please wait while the question is playing";
+    return 'Please wait until the introduction finishes';
+  if (isPlaying.value) return 'Please wait while the question is playing';
   if (isButtonCooldown.value)
-    return "Please wait before repeating the question again";
-  return "Repeat the current question";
+    return 'Please wait before repeating the question again';
+  return 'Repeat the current question';
 });
 
 // 5. Watch/WatchEffect
@@ -348,11 +348,11 @@ const repeatButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -360,7 +360,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/carCounting/carCountIntro.mp3");
+      const introAudio = playIntro('/carCounting/carCountIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -375,9 +375,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -409,37 +409,37 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates random number of cars as Questions
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 5) + 1;
     if (!randQueNum.includes(num)) {
       randQueNum.push(num);
       const answerMap = {
-        1: "one",
-        2: "two",
-        3: "three",
-        4: "four",
-        5: "five",
+        1: 'one',
+        2: 'two',
+        3: 'three',
+        4: 'four',
+        5: 'five',
       };
       answers.push(answerMap[num]);
     }
   }
-  console.log("Random Numbers: ", randQueNum);
-  console.log("Answers: ", answers);
+  console.log('Random Numbers: ', randQueNum);
+  console.log('Answers: ', answers);
 };
 
 /**
@@ -447,6 +447,7 @@ const generateQuestions = () => {
  */
 const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && !isPlaying.value) {
+    isButtonCooldown.value = true;
     isPlaying.value = true;
 
     // Stop all current audios
@@ -455,17 +456,17 @@ const playNextQuestion = async () => {
 
     const audiosToPlay = [];
 
-    playQuestion("Question Number " + (numOfAudiosPlayed.value + 1));
+    await playQuestion('Question Number ' + (numOfAudiosPlayed.value + 1));
 
     // Add the car passing by audios
     for (let i = 0; i < randQueNum[numOfAudiosPlayed.value]; i++) {
-      audiosToPlay.push("/assets/carCounting/carpassby.mp3");
+      audiosToPlay.push('/assets/carCounting/carpassby.mp3');
     }
 
     // Play all car audios in sequence
     for (const audioSrc of audiosToPlay) {
       await new Promise((resolve) => {
-        console.log("Playing - " + audioSrc);
+        console.log('Playing - ' + audioSrc);
         const audio = new Audio(audioSrc);
         audio.play();
         audio.onended = resolve;
@@ -474,9 +475,10 @@ const playNextQuestion = async () => {
     }
 
     // Add the final audio
-    playQuestion("How many cars did you hear?");
+    await playQuestion('How many cars did you hear?');
 
     isPlaying.value = false;
+    isButtonCooldown.value = false;
   }
 };
 
@@ -492,32 +494,37 @@ const toggleRecording = () => {
     if (!isRecording.value) {
       // Start recording
       isRecording.value = true;
-      playSound("ding-sound.mp3");
+      playSound('ding-sound.mp3');
 
       startListening((transcript) => {
         transcription.value = transcript;
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       // Get the final transcript
       const finalTranscript = transcription.value;
 
       // Process the answer
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", randQueNum[numOfAudiosPlayed.value]);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', randQueNum[numOfAudiosPlayed.value]);
 
-      const cleanedInput = finalTranscript.trim().toLowerCase().replace(/[^\w\s]/g, ''); // removes punctuation
-      if (cleanedInput.includes(answers[numOfAudiosPlayed.value].toLowerCase())) {
+      const cleanedInput = finalTranscript
+        .trim()
+        .toLowerCase()
+        .replace(/[^\w\s]/g, ''); // removes punctuation
+      if (
+        cleanedInput.includes(answers[numOfAudiosPlayed.value].toLowerCase())
+      ) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
+        console.log('Wrong Answer!');
         const incorectAudio =
-          "The correct answer is " + answers[numOfAudiosPlayed.value];
-        playSound("incorrectaudio.mp3");
+          'The correct answer is ' + answers[numOfAudiosPlayed.value];
+        playSound('incorrectaudio.mp3');
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -530,16 +537,15 @@ const toggleRecording = () => {
 
       // Reset transcription for next question
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -562,7 +568,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Car Counting game - Question #" +
+      'Repeating question for Car Counting game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -573,11 +579,11 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 4000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isPlaying.value) {
-    console.log("Cannot repeat question while audio is playing");
+    console.log('Cannot repeat question while audio is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -586,7 +592,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };
@@ -594,12 +600,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -161,7 +161,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -190,10 +190,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -229,7 +229,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -270,21 +270,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -299,7 +299,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -329,32 +329,32 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -362,7 +362,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/colorGame/colorIntro.mp3");
+      const introAudio = playIntro('/colorGame/colorIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -377,9 +377,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -411,7 +411,7 @@ const checkDeviceType = () => {
  * Generates color recognition questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -420,25 +420,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/crazyColorsDB.json")
+  fetch('/assets/questionsDb/crazyColorsDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["ColorQuizGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['ColorQuizGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["ColorQuizGame"]["Questions"]["Easy"];
+      questionsDb = data['ColorQuizGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -455,34 +458,34 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-  .toLowerCase()
-  .replace(/[^a-z0-9\s]/gi, "") // removes everything except letters, numbers, and spaces
-  .split(/\s+/)
-  .filter(Boolean); // removes empty strings
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/gi, '') // removes everything except letters, numbers, and spaces
+        .split(/\s+/)
+        .filter(Boolean); // removes empty strings
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -494,9 +497,8 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
@@ -504,7 +506,7 @@ const toggleRecording = () => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -518,13 +520,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -539,7 +541,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Color Game - Question #" +
+      'Repeating question for Color Game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -550,9 +552,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -561,7 +563,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -569,11 +571,11 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 </script>

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -161,7 +161,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -190,10 +190,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -229,7 +229,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -269,21 +269,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -298,7 +298,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -328,23 +328,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -353,12 +353,12 @@ const recordButtonTitle = computed(() => {
 // 6. Lifecycle Hooks
 onMounted(() => {
   // Request microphone access on page load
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   // Check device type initially and set up listener for window resize
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   // Generate questions
   generateQuestions();
@@ -367,7 +367,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/definitionDetective/definitionIntro.mp3");
+      const introAudio = playIntro('/definitionDetective/definitionIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -382,9 +382,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -416,7 +416,7 @@ const checkDeviceType = () => {
  * Generates multiplication questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -425,28 +425,31 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/definitionDetectiveDB.json")
+  fetch('/assets/questionsDb/definitionDetectiveDB.json')
     .then((response) => response.json())
     .then((data) => {
       console.log(
-        "Questions:",
-        data["DefinitionDetectiveGame"]["Questions"]["Easy"]
+        'Questions:',
+        data['DefinitionDetectiveGame']['Questions']['Easy']
       );
       // Process the questions data as needed
-      questionsDb = data["DefinitionDetectiveGame"]["Questions"]["Easy"];
+      questionsDb = data['DefinitionDetectiveGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -464,34 +467,34 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       // Get the final transcript
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -505,9 +508,8 @@ const toggleRecording = () => {
 
       // Reset transcription for next question
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
@@ -515,7 +517,7 @@ const toggleRecording = () => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -529,11 +531,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -550,7 +552,7 @@ const repeatQuestion = () => {
 
     // logging message for repeating question
     console.log(
-      "Repeating question for Definition Detective game - Question #" +
+      'Repeating question for Definition Detective game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -562,9 +564,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3500);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -573,7 +575,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };
@@ -581,12 +583,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8.Exposed Values

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -160,7 +160,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -188,10 +188,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -227,7 +227,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -267,21 +267,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -296,7 +296,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -326,23 +326,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -350,11 +350,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -362,7 +362,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/divisionduel/divintro.mp3");
+      const introAudio = playIntro('/divisionduel/divintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -377,9 +377,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -411,14 +411,14 @@ const checkDeviceType = () => {
  * Generates division questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/divisionDb.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/divisionDb.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["DivisionGame"]["Questions"]["Easy"],
-        ...data["DivisionGame"]["Questions"]["Medium"],
-        ...data["DivisionGame"]["Questions"]["Hard"],
+        ...data['DivisionGame']['Questions']['Easy'],
+        ...data['DivisionGame']['Questions']['Medium'],
+        ...data['DivisionGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -430,21 +430,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -461,32 +464,32 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -498,16 +501,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -521,13 +523,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -542,7 +544,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Division Duel game - Question #" +
+      'Repeating question for Division Duel game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -553,9 +555,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3500);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -564,7 +566,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };
@@ -572,12 +574,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8.Exposed Values

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -163,7 +163,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -192,10 +192,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -231,7 +231,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -271,21 +271,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -300,7 +300,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -330,23 +330,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -354,11 +354,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -366,7 +366,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/fruitFrenzy/fruitIntro.mp3");
+      const introAudio = playIntro('/fruitFrenzy/fruitIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -381,9 +381,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -415,14 +415,14 @@ const checkDeviceType = () => {
  * Generates fruit counting questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/fruitFrenzy.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/fruitFrenzy.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["FruitFrenzy"]["Questions"]["Easy"],
-        ...data["FruitFrenzy"]["Questions"]["Medium"],
-        ...data["FruitFrenzy"]["Questions"]["Hard"],
+        ...data['FruitFrenzy']['Questions']['Easy'],
+        ...data['FruitFrenzy']['Questions']['Medium'],
+        ...data['FruitFrenzy']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -434,21 +434,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -465,38 +468,37 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
         }, 1000);
-
       }
 
       stopListening();
@@ -504,16 +506,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -527,13 +528,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -548,7 +549,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Fruit Frenzy game - Question #" +
+      'Repeating question for Fruit Frenzy game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -559,9 +560,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -570,7 +571,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };
@@ -578,12 +579,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/GameZoneList.vue
+++ b/src/pages/GameZone/GameZoneList/GameZoneList.vue
@@ -37,10 +37,10 @@ watch(() => props.type, (newType, oldType) => {
  -->
 
 <script setup>
-import { ref, defineProps, onBeforeMount, watch } from "vue";
-import GameZoneCard from "../GameZoneCard/GameZoneCard.vue";
-import { getLanguageGames, getMathGames } from "../GameDB.js";
-import { useRouter } from "vue-router"; 
+import { ref, defineProps, onBeforeMount, watch } from 'vue';
+import GameZoneCard from '../GameZoneCard/GameZoneCard.vue';
+import { getLanguageGames, getMathGames } from '../GameDB.js';
+import { useRouter } from 'vue-router';
 
 const props = defineProps({
   type: Number,
@@ -49,7 +49,7 @@ const props = defineProps({
 const getGames = (type) =>
   (games.value = type === 1 ? getLanguageGames() : getMathGames());
 const games = ref([]);
-const router = useRouter(); 
+const router = useRouter();
 
 const openGame = (url) => {
   router.push(url);
@@ -66,28 +66,38 @@ watch(
 );
 
 const getCardClass = (index) => {
-  const pattern = ["w-[67%] tablet:w-[50%] mobile:w-[100%]", "w-[30%] tablet:w-[45%] mobile:w-[48%]", "w-[30%] tablet:w-[45%] mobile:w-[48%]", "w-[67%] tablet:w-[50%] mobile:w-[100%]"];
+  const pattern = [
+    'w-[67%] tablet:w-[50%] mobile:w-[100%]',
+    'w-[30%] tablet:w-[45%] mobile:w-[48%]',
+    'w-[30%] tablet:w-[45%] mobile:w-[48%]',
+    'w-[67%] tablet:w-[50%] mobile:w-[100%]',
+  ];
   return pattern[index % 4];
-}
+};
 </script>
 
 <template>
   <div class="w-full flex justify-center align-center">
     <div class="w-full gap-1 mobile:gap-0 flex flex-wrap justify-between">
-      <div class="h-auto mb-10 mobile:w-full" :class="getCardClass(index)" v-for="(game, index) in games" :key="index">
-        <GameZoneCard 
-          :title="game.title" 
-          :icon="game.icon" 
-          :textColor="game.textColor" 
+      <div
+        class="h-auto mb-10 mobile:w-full"
+        :class="getCardClass(index)"
+        v-for="(game, index) in games"
+        :key="index"
+      >
+        <GameZoneCard
+          :title="game.title"
+          :icon="game.icon"
+          :textColor="game.textColor"
           :bgColor="game.bgColor"
-          :url="game.url" @selectGame="openGame" 
-          :description="game.description" 
-          :bgDecoration="game.bgDecoration ?? false" 
+          :url="game.url"
+          @selectGame="openGame"
+          :description="game.description"
+          :bgDecoration="game.bgDecoration ?? false"
           :bgImage="game.bgImage"
           class="hover:scale-105 hover:transition hover:duration-500"
         />
       </div>
     </div>
   </div>
-
 </template>

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -160,7 +160,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -189,10 +189,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -228,7 +228,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -268,21 +268,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -297,7 +297,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -327,23 +327,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -351,11 +351,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -363,7 +363,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/monkeyMadness/monkeyintro.mp3");
+      const introAudio = playIntro('/monkeyMadness/monkeyintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -378,9 +378,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -412,14 +412,14 @@ const checkDeviceType = () => {
  * Generates monkey madness questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/monkeyMadnessDB.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/monkeyMadnessDB.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["MonkeyMadnessGame"]["Questions"]["Easy"],
-        ...data["MonkeyMadnessGame"]["Questions"]["Medium"],
-        ...data["MonkeyMadnessGame"]["Questions"]["Hard"],
+        ...data['MonkeyMadnessGame']['Questions']['Easy'],
+        ...data['MonkeyMadnessGame']['Questions']['Medium'],
+        ...data['MonkeyMadnessGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -431,21 +431,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -462,32 +465,32 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -499,16 +502,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -522,13 +524,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -543,7 +545,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Monkey Madness game - Question #" +
+      'Repeating question for Monkey Madness game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -554,9 +556,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -565,7 +567,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -573,12 +575,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -162,7 +162,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -191,10 +191,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -230,7 +230,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -270,21 +270,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -299,7 +299,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -329,23 +329,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -353,11 +353,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -366,7 +366,7 @@ onMounted(() => {
     if (newVal) {
       isIntroPlaying.value = true;
       const introAudio = playIntro(
-        "/multiplicationmadness/multiplicationintro.mp3"
+        '/multiplicationmadness/multiplicationintro.mp3'
       );
       currentAudios.push(introAudio);
       introAudio.onended = () => {
@@ -382,9 +382,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -416,14 +416,14 @@ const checkDeviceType = () => {
  * Generates multiplication questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/multiplication.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/multiplication.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["MultiplicationGame"]["Questions"]["Easy"],
-        ...data["MultiplicationGame"]["Questions"]["Medium"],
-        ...data["MultiplicationGame"]["Questions"]["Hard"],
+        ...data['MultiplicationGame']['Questions']['Easy'],
+        ...data['MultiplicationGame']['Questions']['Medium'],
+        ...data['MultiplicationGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -435,21 +435,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -466,38 +469,37 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
         }, 1000);
-
       }
 
       stopListening();
@@ -505,16 +507,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -528,13 +529,13 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -549,7 +550,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Multiplication Madness game - Question #" +
+      'Repeating question for Multiplication Madness game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -560,9 +561,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -571,7 +572,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -579,12 +580,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/OddOneOut.vue
+++ b/src/pages/GameZone/GameZoneList/OddOneOut.vue
@@ -163,7 +163,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -192,10 +192,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -231,7 +231,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -271,21 +271,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -300,7 +300,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -330,23 +330,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -354,11 +354,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -366,7 +366,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/oddoneout/oddoneoutintro.mp3");
+      const introAudio = playIntro('/oddoneout/oddoneoutintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -381,9 +381,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -415,7 +415,7 @@ const checkDeviceType = () => {
  * Generates odd one out questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -424,25 +424,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/oddOneOutDB.json")
+  fetch('/assets/questionsDb/oddOneOutDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["OddOneOutGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['OddOneOutGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["OddOneOutGame"]["Questions"]["Easy"];
+      questionsDb = data['OddOneOutGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -458,7 +461,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Odd One Out game - Question #" +
+      'Repeating question for Odd One Out game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -469,9 +472,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -488,38 +491,37 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
         }, 1000);
-
       }
 
       stopListening();
@@ -527,16 +529,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -550,11 +551,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -562,7 +563,7 @@ const goBack = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -570,12 +571,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -162,7 +162,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -191,10 +191,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -230,7 +230,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -270,21 +270,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -299,7 +299,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -329,23 +329,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait before repeating the question again";
-  return "Record your answer";
+    return 'Please wait before repeating the question again';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -353,11 +353,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -365,7 +365,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/partOfSpeech/partofspeechintro.mp3");
+      const introAudio = playIntro('/partOfSpeech/partofspeechintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -380,9 +380,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -414,7 +414,7 @@ const checkDeviceType = () => {
  * Generates part of speech questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -423,25 +423,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/partOfSpeechDB.json")
+  fetch('/assets/questionsDb/partOfSpeechDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["PartOfSpeechGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['PartOfSpeechGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["PartOfSpeechGame"]["Questions"]["Easy"];
+      questionsDb = data['PartOfSpeechGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -458,33 +461,33 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -496,16 +499,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -519,11 +521,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -538,7 +540,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Part of Speech game - Question #" +
+      'Repeating question for Part of Speech game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -549,9 +551,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 4000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -560,7 +562,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -568,12 +570,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -163,7 +163,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -192,10 +192,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -231,7 +231,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -271,21 +271,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -300,7 +300,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -330,24 +330,24 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "", // Apply cooldown/intro disable class
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '', // Apply cooldown/intro disable class
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
     // Check cooldown for title
-    return "Please wait before repeating the question again";
-  return "Record your answer";
+    return 'Please wait before repeating the question again';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -355,11 +355,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -367,7 +367,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/polarpairing/oppintro.mp3");
+      const introAudio = playIntro('/polarpairing/oppintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -382,9 +382,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -416,7 +416,7 @@ const checkDeviceType = () => {
  * Generates polar pairing questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -425,25 +425,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/polarPairingDB.json")
+  fetch('/assets/questionsDb/polarPairingDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["PolarPairingGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['PolarPairingGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["PolarPairingGame"]["Questions"]["Easy"];
+      questionsDb = data['PolarPairingGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -459,7 +462,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Polar Pairing game - Question #" +
+      'Repeating question for Polar Pairing game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -470,9 +473,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -489,36 +492,36 @@ const toggleRecording = () => {
     }, false);
   } else {
     isButtonCooldown.value = true;
-    console.log("Processing recording...");
+    console.log('Processing recording...');
     stopListening();
     isRecording.value = false;
 
     const finalTranscript = transcription.value;
 
     if (currentQuestion.value) {
-      console.log("Question is: ", currentQuestion.value["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", currentQuestion.value["A"]);
+      console.log('Question is: ', currentQuestion.value['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', currentQuestion.value['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(currentQuestion.value['A'])
+        ? currentQuestion.value['A'].map((a) => a.toLowerCase())
+        : [currentQuestion.value['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
+        console.log('Wrong Answer!');
         const incorrectAudio =
-          "The correct answer is " + currentQuestion.value["A"][0];
-        playSound("incorrectaudio.mp3");
-        
+          'The correct answer is ' + currentQuestion.value['A'][0];
+        playSound('incorrectaudio.mp3');
+
         setTimeout(() => {
           currentAudios.push(playQuestion(incorrectAudio));
         }, 1000);
@@ -528,16 +531,15 @@ const toggleRecording = () => {
     numOfAudiosPlayed.value++;
 
     setTimeout(() => {
-      transcription.value = "";
+      transcription.value = '';
       setTimeout(() => {
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped. Cooldown ended.");
+        console.log('Recording processed and stopped. Cooldown ended.');
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 500);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 1000);
@@ -551,11 +553,11 @@ const toggleRecording = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
@@ -564,7 +566,7 @@ const goBack = () => {
  */
 const startFirstQuestion = () => {
   if (isIntroPlaying.value) return;
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -572,12 +574,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -162,7 +162,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -191,10 +191,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -230,7 +230,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -270,21 +270,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -299,7 +299,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -329,23 +329,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -353,11 +353,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -365,7 +365,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/shapeSharks/shapeintro.mp3");
+      const introAudio = playIntro('/shapeSharks/shapeintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -380,9 +380,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -414,27 +414,27 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates shape questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/shapeSharkDB.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/shapeSharkDB.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["ShapeSharkGame"]["Questions"]["Easy"],
-        ...data["ShapeSharkGame"]["Questions"]["Medium"],
-        ...data["ShapeSharkGame"]["Questions"]["Hard"],
+        ...data['ShapeSharkGame']['Questions']['Easy'],
+        ...data['ShapeSharkGame']['Questions']['Medium'],
+        ...data['ShapeSharkGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -446,21 +446,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -477,29 +480,29 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       if (currentQuestion.value) {
-        console.log("Question is: ", currentQuestion.value["Q"]);
-        console.log("User Answer:", finalTranscript);
-        console.log("Correct Answer:", currentQuestion.value["A"]);
+        console.log('Question is: ', currentQuestion.value['Q']);
+        console.log('User Answer:', finalTranscript);
+        console.log('Correct Answer:', currentQuestion.value['A']);
 
         if (
-          currentQuestion.value["A"].some((answer) =>
+          currentQuestion.value['A'].some((answer) =>
             finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
           )
         ) {
           score.value++;
-          console.log("Correct Answer!");
-          playSound("correctaudio.mp3");
+          console.log('Correct Answer!');
+          playSound('correctaudio.mp3');
         } else {
-          console.log("Wrong Answer!");
+          console.log('Wrong Answer!');
 
           const incorrectAudio =
-            "The correct answer is " + currentQuestion.value["A"][0];
-          playSound("incorrectaudio.mp3");
+            'The correct answer is ' + currentQuestion.value['A'][0];
+          playSound('incorrectaudio.mp3');
 
           setTimeout(() => {
             currentAudios.push(playQuestion(incorrectAudio));
@@ -512,16 +515,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -543,7 +545,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Shape Shark game - Question #" +
+      'Repeating question for Shape Shark game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -554,9 +556,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -565,7 +567,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -573,12 +575,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/SpellingBee.vue
+++ b/src/pages/GameZone/GameZoneList/SpellingBee.vue
@@ -170,7 +170,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -199,10 +199,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -238,7 +238,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -277,21 +277,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -306,7 +306,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 const isListening = ref(false);
 
 // UI control states
@@ -337,23 +337,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -363,9 +363,9 @@ const recordButtonTitle = computed(() => {
 onMounted(() => {
   checkDeviceType();
 
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   generateQuestions();
@@ -374,7 +374,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/spellingBee/spellingintro.mp3");
+      const introAudio = playIntro('/spellingBee/spellingintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -389,9 +389,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -423,18 +423,18 @@ const checkDeviceType = () => {
  * Function to handle back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates spelling questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 15);
@@ -443,25 +443,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/spellingBeeDB.json")
+  fetch('/assets/questionsDb/spellingBeeDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["SpellingBeeGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['SpellingBeeGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["SpellingBeeGame"]["Questions"]["Easy"];
+      questionsDb = data['SpellingBeeGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -479,28 +482,28 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       if (currentQuestion.value) {
-        console.log("Question is: ", currentQuestion.value["Q"]);
-        console.log("User Answer:", finalTranscript);
-        console.log("Correct Answer:", currentQuestion.value["A"]);
+        console.log('Question is: ', currentQuestion.value['Q']);
+        console.log('User Answer:', finalTranscript);
+        console.log('Correct Answer:', currentQuestion.value['A']);
 
         if (
-          currentQuestion.value["A"].some((answer) =>
+          currentQuestion.value['A'].some((answer) =>
             finalTranscript.trim().toLowerCase().includes(answer.toLowerCase())
           )
         ) {
           score.value++;
-          console.log("Correct Answer!");
-          playSound("correctaudio.mp3");
+          console.log('Correct Answer!');
+          playSound('correctaudio.mp3');
         } else {
-          console.log("Wrong Answer!");
+          console.log('Wrong Answer!');
           const incorrectAudio =
-            "The correct answer is " + currentQuestion.value["A"][0];
-          playSound("incorrectaudio.mp3");
+            'The correct answer is ' + currentQuestion.value['A'][0];
+          playSound('incorrectaudio.mp3');
 
           setTimeout(() => {
             currentAudios.push(playQuestion(incorrectAudio));
@@ -514,16 +517,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -546,7 +548,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Spelling Bee game - Question #" +
+      'Repeating question for Spelling Bee game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -557,9 +559,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 3000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -568,7 +570,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };
@@ -576,12 +578,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -162,7 +162,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -191,10 +191,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -230,7 +230,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -270,21 +270,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -299,7 +299,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -329,23 +329,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -353,11 +353,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -365,7 +365,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/subtractionSafari/subtractionintro.mp3");
+      const introAudio = playIntro('/subtractionSafari/subtractionintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -380,9 +380,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -414,27 +414,27 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Save the source category to sessionStorage
-  sessionStorage.setItem("gameCategory", "math");
+  sessionStorage.setItem('gameCategory', 'math');
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates subtraction questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
-  fetch("/assets/questionsDb/subtractionDB.json")
+  console.log('Generating Questions...');
+  fetch('/assets/questionsDb/subtractionDB.json')
     .then((response) => response.json())
     .then((data) => {
       let allQuestions = [
-        ...data["SubtractionGame"]["Questions"]["Easy"],
-        ...data["SubtractionGame"]["Questions"]["Medium"],
-        ...data["SubtractionGame"]["Questions"]["Hard"],
+        ...data['SubtractionGame']['Questions']['Easy'],
+        ...data['SubtractionGame']['Questions']['Medium'],
+        ...data['SubtractionGame']['Questions']['Hard'],
       ];
 
       // Only generate 5 random questions
@@ -446,21 +446,24 @@ const generateQuestions = () => {
       }
 
       questionsDb = allQuestions;
-      console.log("Questions generated!");
+      console.log('Questions generated!');
       console.log(questionsDb);
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -477,38 +480,37 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
         }, 1000);
-
       }
 
       stopListening();
@@ -516,16 +518,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -547,7 +548,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Subtraction Safari game - Question #" +
+      'Repeating question for Subtraction Safari game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -558,9 +559,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -569,7 +570,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -577,12 +578,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -162,7 +162,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -191,10 +191,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -230,7 +230,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -270,21 +270,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -299,7 +299,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -329,23 +329,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -353,11 +353,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -365,7 +365,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/syllableSorting/syllableIntro.mp3");
+      const introAudio = playIntro('/syllableSorting/syllableIntro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -380,9 +380,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -414,18 +414,18 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates syllable questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 10);
@@ -434,28 +434,31 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/SyllableGameDB.json")
+  fetch('/assets/questionsDb/SyllableGameDB.json')
     .then((response) => response.json())
     .then((data) => {
       console.log(
-        "Questions:",
-        data["SyllableCountingGame"]["Questions"]["Easy"]
+        'Questions:',
+        data['SyllableCountingGame']['Questions']['Easy']
       );
       // Process the questions data as needed
-      questionsDb = data["SyllableCountingGame"]["Questions"]["Easy"];
+      questionsDb = data['SyllableCountingGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -472,33 +475,33 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -511,9 +514,8 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         // Move to next question or end game
         if (numOfAudiosPlayed.value < 5) {
@@ -521,7 +523,7 @@ const toggleRecording = () => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -543,7 +545,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Syllable Sorting game - Question #" +
+      'Repeating question for Syllable Sorting game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -554,9 +556,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -565,7 +567,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1;
   playNextQuestion();
 };
@@ -573,12 +575,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/Vocab.vue
+++ b/src/pages/GameZone/GameZoneList/Vocab.vue
@@ -163,7 +163,7 @@
                   :disabled="isIntroPlaying"
                   :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
                 >
-                  {{ isIntroPlaying ? "Please wait..." : "Start Questions" }}
+                  {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
                 </button>
               </div>
 
@@ -192,10 +192,10 @@
                   <span class="text-lg font-medium">
                     {{
                       isRecording
-                        ? "Stop Recording"
+                        ? 'Stop Recording'
                         : isTablet || isMobile
-                        ? "Record"
-                        : "Record Answer"
+                        ? 'Record'
+                        : 'Record Answer'
                     }}
                   </span>
                   <img
@@ -231,7 +231,7 @@
                   "
                 >
                   <span class="text-lg font-medium">{{
-                    isTablet || isMobile ? "Repeat" : "Repeat Question"
+                    isTablet || isMobile ? 'Repeat' : 'Repeat Question'
                   }}</span>
                   <img
                     src="/assets/gameImages/buttons/repeat.png"
@@ -271,21 +271,21 @@
 
 <script setup>
 // 1. Imports
-import { onMounted, onUnmounted, ref, watch, computed } from "vue";
-import GamePagesHeader from "../../Header/GamePagesHeader.vue";
-import GamePagesFooter from "../../Footer/GamePagesFooter.vue"
-import { requestMicPermission } from "../../../Utilities/requestMicAccess";
+import { onMounted, onUnmounted, ref, watch, computed } from 'vue';
+import GamePagesHeader from '../../Header/GamePagesHeader.vue';
+import GamePagesFooter from '../../Footer/GamePagesFooter.vue';
+import { requestMicPermission } from '../../../Utilities/requestMicAccess';
 import {
   playIntro,
   playQuestion,
   playSound,
   stopAudios,
   playScore,
-} from "../../../Utilities/playAudio";
+} from '../../../Utilities/playAudio';
 import {
   startListening,
   stopListening,
-} from "../../../Utilities/speechRecognition";
+} from '../../../Utilities/speechRecognition';
 
 // 2. Props / Emits
 // (none in this component)
@@ -300,7 +300,7 @@ let questionsDb = [];
 const numOfAudiosPlayed = ref(0);
 const score = ref(0);
 const isRecording = ref(false);
-const transcription = ref("");
+const transcription = ref('');
 
 // UI control states
 const playButton = ref(false);
@@ -330,23 +330,23 @@ const isButtonDisabled = computed(
 );
 
 const recordButtonClasses = computed(() => [
-  "flex items-center justify-center shadow-md",
+  'flex items-center justify-center shadow-md',
   isTablet.value
-    ? "w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
+    ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : isMobile.value
-    ? "w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]"
-    : "gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]",
-  isRecording.value ? "bg-red-500" : "bg-[#087BB4]",
-  "text-white",
-  isButtonDisabled.value ? "opacity-50 cursor-not-allowed" : "",
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+  isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
+  'text-white',
+  isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
 ]);
 
 const recordButtonTitle = computed(() => {
   if (isIntroPlaying.value)
-    return "Please wait until the introduction finishes";
+    return 'Please wait until the introduction finishes';
   if (isButtonCooldown.value)
-    return "Please wait until the question finishes playing";
-  return "Record your answer";
+    return 'Please wait until the question finishes playing';
+  return 'Record your answer';
 });
 
 // 5. Watch/WatchEffect
@@ -354,11 +354,11 @@ const recordButtonTitle = computed(() => {
 
 // 6. Lifecycle Hooks
 onMounted(() => {
-  console.log("Requesting microphone access...");
+  console.log('Requesting microphone access...');
   requestMicPermission();
 
   checkDeviceType();
-  window.addEventListener("resize", checkDeviceType);
+  window.addEventListener('resize', checkDeviceType);
 
   generateQuestions();
 
@@ -366,7 +366,7 @@ onMounted(() => {
   watch(playButton, (newVal) => {
     if (newVal) {
       isIntroPlaying.value = true;
-      const introAudio = playIntro("/vocabVortex/vortexintro.mp3");
+      const introAudio = playIntro('/vocabVortex/vortexintro.mp3');
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
@@ -381,9 +381,9 @@ onMounted(() => {
 
 onUnmounted(() => {
   // Stop audio playback and cleanup listeners
-  console.log("Navigated Back!");
+  console.log('Navigated Back!');
   stopAudios(currentAudios);
-  window.removeEventListener("resize", checkDeviceType);
+  window.removeEventListener('resize', checkDeviceType);
 });
 
 // 7. Functions/Methods
@@ -415,18 +415,18 @@ const checkDeviceType = () => {
  * Handles the back button click
  */
 const goBack = () => {
-  console.log("Going back...");
+  console.log('Going back...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/game-zone";
+  window.location.href = '/game-zone';
 };
 
 /**
  * Generates vocabulary questions using JSON file
  */
 const generateQuestions = () => {
-  console.log("Generating Questions...");
+  console.log('Generating Questions...');
   // Generate 5 random numbers for the questions
   while (randQueNum.length < 5) {
     let num = Math.floor(Math.random() * 15);
@@ -435,25 +435,28 @@ const generateQuestions = () => {
     }
   }
   // Fetch questions from JSON file
-  fetch("/assets/questionsDb/VocabVortexDB.json")
+  fetch('/assets/questionsDb/VocabVortexDB.json')
     .then((response) => response.json())
     .then((data) => {
-      console.log("Questions:", data["VocabVortexGame"]["Questions"]["Easy"]);
+      console.log('Questions:', data['VocabVortexGame']['Questions']['Easy']);
       // Process the questions data as needed
-      questionsDb = data["VocabVortexGame"]["Questions"]["Easy"];
+      questionsDb = data['VocabVortexGame']['Questions']['Easy'];
     })
     .catch((error) => {
-      console.error("Error fetching questions:", error);
+      console.error('Error fetching questions:', error);
     });
 };
 
 /**
  * Plays the next question
  */
-const playNextQuestion = () => {
+const playNextQuestion = async () => {
   if (numOfAudiosPlayed.value < 5 && currentQuestion.value) {
     console.log(currentQuestion.value);
-    currentAudios.push(playQuestion(currentQuestion.value["Q"]));
+
+    isButtonCooldown.value = true;
+    await playQuestion(currentQuestion.value['Q']);
+    isButtonCooldown.value = false;
   }
 };
 
@@ -470,33 +473,33 @@ const toggleRecording = () => {
       }, false);
     } else {
       isButtonCooldown.value = true;
-      console.log("Processing recording...");
+      console.log('Processing recording...');
 
       const finalTranscript = transcription.value;
 
       // Process the answer
       const question = questionsDb[randQueNum[numOfAudiosPlayed.value]];
-      console.log("Question is: ", question["Q"]);
-      console.log("User Answer:", finalTranscript);
-      console.log("Correct Answer:", question["A"]);
+      console.log('Question is: ', question['Q']);
+      console.log('User Answer:', finalTranscript);
+      console.log('Correct Answer:', question['A']);
 
       const userWords = finalTranscript
-      .toLowerCase()
-      .replace(/[.,!?]/g, "")
-      .split(/\s+/);
+        .toLowerCase()
+        .replace(/[.,!?]/g, '')
+        .split(/\s+/);
 
-      const correctAnswers = Array.isArray(question["A"])
-        ? question["A"].map((a) => a.toLowerCase())
-        : [question["A"].toLowerCase()];
+      const correctAnswers = Array.isArray(question['A'])
+        ? question['A'].map((a) => a.toLowerCase())
+        : [question['A'].toLowerCase()];
 
-      if (userWords.some((word) => correctAnswers.includes(word))){
+      if (userWords.some((word) => correctAnswers.includes(word))) {
         score.value++;
-        console.log("Correct Answer!");
-        playSound("correctaudio.mp3");
+        console.log('Correct Answer!');
+        playSound('correctaudio.mp3');
       } else {
-        console.log("Wrong Answer!");
-        playSound("incorrectaudio.mp3");
-        const incorectAudio = "The correct answer is " + question["A"][0];
+        console.log('Wrong Answer!');
+        playSound('incorrectaudio.mp3');
+        const incorectAudio = 'The correct answer is ' + question['A'][0];
 
         setTimeout(() => {
           currentAudios.push(playQuestion(incorectAudio));
@@ -508,16 +511,15 @@ const toggleRecording = () => {
       numOfAudiosPlayed.value++;
 
       setTimeout(() => {
-        transcription.value = "";
-        isButtonCooldown.value = false;
-        console.log("Recording processed and stopped");
+        transcription.value = '';
+        console.log('Recording processed and stopped');
 
         if (numOfAudiosPlayed.value < 5) {
           setTimeout(() => {
             playNextQuestion();
           }, 2000);
         } else {
-          console.log("Game Over!");
+          console.log('Game Over!');
           setTimeout(() => {
             playScore(score.value);
           }, 2000);
@@ -539,7 +541,7 @@ const repeatQuestion = () => {
     isButtonCooldown.value = true;
 
     console.log(
-      "Repeating question for Vocabulary Vortex game - Question #" +
+      'Repeating question for Vocabulary Vortex game - Question #' +
         (numOfAudiosPlayed.value + 1)
     );
 
@@ -550,9 +552,9 @@ const repeatQuestion = () => {
       isButtonCooldown.value = false;
     }, 5000);
   } else if (isIntroPlaying.value) {
-    console.log("Cannot repeat question while introduction is playing");
+    console.log('Cannot repeat question while introduction is playing');
   } else if (isButtonCooldown.value) {
-    console.log("Please wait before repeating the question again");
+    console.log('Please wait before repeating the question again');
   }
 };
 
@@ -561,7 +563,7 @@ const repeatQuestion = () => {
  * Only used for mobile devices
  */
 const startFirstQuestion = () => {
-  console.log("Starting first question...");
+  console.log('Starting first question...');
   numOfAudiosPlayed.value = 1; // This will trigger the buttons to show
   playNextQuestion();
 };
@@ -569,12 +571,12 @@ const startFirstQuestion = () => {
 /**
  * Handles the something not working button click
  */
- const handleSthNotWorkingButtonClick = () => {
-  console.log("Navigating to Troubleshooting Page...");
+const handleSthNotWorkingButtonClick = () => {
+  console.log('Navigating to Troubleshooting Page...');
   // Stop all audio playback before navigating away
   stopAudios(currentAudios);
   // Force navigate to the game zone page
-  window.location.href = "/troubleshooting";
+  window.location.href = '/troubleshooting';
 };
 
 // 8. Exposed Values


### PR DESCRIPTION
# References
Issues
- https://github.com/Crustaly/audemywebsite/issues/95
- https://github.com/Crustaly/audemywebsite/issues/98

# Describe your changes
- Made sure the record button is only enabled after the question has been fully given to the user. The `playAudioPath` method in the `playAudio` file has been updated to resolve only after the audio/question finishes playing.
- This PR also addresses this [issue](https://github.com/Crustaly/audemywebsite/issues/98)

As there was no release/fix branch to base it on, I used the main branch as the base branch.