### PR TITLE
Fix/Change baseURL to use environment variable for prod and dev environments

### DIFF
--- a/src/pages/ResetPassword/ResetPassword.vue
+++ b/src/pages/ResetPassword/ResetPassword.vue
@@ -9,6 +9,8 @@ const confirmPassword = ref("");
 const token = ref("");
 const router = useRouter();
 
+let errorMessage = ref("")
+
 onMounted(() => {
     // Get the token from the URL query parameters
     const query = new URLSearchParams(window.location.search);

--- a/src/pages/api/db/get_user.js
+++ b/src/pages/api/db/get_user.js
@@ -2,9 +2,11 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+const baseURL = process.env.BASE_URL
+
 export default async function handler(req, res) {
     // Set CORS headers (you can either use "*" for all origins or a specific one like below)
-    res.setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
+    res.setHeader("Access-Control-Allow-Origin", baseURL);
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     res.setHeader(
         "Access-Control-Allow-Headers",

--- a/src/pages/api/reset-password.js
+++ b/src/pages/api/reset-password.js
@@ -2,12 +2,13 @@ import { PrismaClient } from '@prisma/client';
 import jwt from 'jsonwebtoken';
 import bcrypt from "bcryptjs";
 
-
 const prisma = new PrismaClient();
+
+const baseURL = process.env.BASE_URL
 
 export default async function handler(req, res) {
     // Set CORS headers (you can either use "*" for all origins or a specific one like below)
-    res.setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
+    res.setHeader("Access-Control-Allow-Origin", baseURL);
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     res.setHeader(
         "Access-Control-Allow-Headers",

--- a/src/pages/api/send-email.js
+++ b/src/pages/api/send-email.js
@@ -4,9 +4,11 @@ import jwt from 'jsonwebtoken';
 
 const prisma = new PrismaClient();
 
+const baseURL = process.env.BASE_URL
+
 export default async function handler(req, res) {
     // Set CORS headers (you can either use "*" for all origins or a specific one like below)
-    res.setHeader("Access-Control-Allow-Origin", "http://localhost:5173");
+    res.setHeader("Access-Control-Allow-Origin", baseURL);
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     res.setHeader(
         "Access-Control-Allow-Headers",
@@ -32,7 +34,7 @@ export default async function handler(req, res) {
 
         // Generate reset token using jwt with expiration time
         const resetToken = jwt.sign({ userId: user.user_id }, process.env.JWT_SECRET, { expiresIn: '10m' });
-        resetLink = `http://localhost:5173/reset-landing-page?user=${user.name}&token=${resetToken}`;
+        resetLink = `${baseURL}/reset-landing-page?user=${user.name}&token=${resetToken}`;
         console.log("Reset link generated.");
 
     } catch (error) {


### PR DESCRIPTION
# Problem
Issue https://github.com/Crustaly/audemywebsite/issues/159: Reset Password button generated in email **navigates incorrectly to local baseURL**

# Approach
- Modified the code to replace the hardcoded URL (`http://localhost:5173`) with an environment variable.
   - **Development Environment**: The updated local URL (`http://localhost:3000`) is now stored in a `.env` file for local development.
   - **Production Environment**: The production URL (`https://audemy.org/`) is stored as an environment variable in **Vercel**.

# Additional Information
- Developers should add the `BASE_URL` variable to their local `.env` file to ensure proper functionality while testing locally.