### PR TITLE
Improve website loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,24 +40,28 @@
     />
     <title>Audemy</title>
 
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://api.tomtom.com/maps-sdk-for-web/cdn/6.x/6.25.0/maps/maps.css"
-    />
-
     <script defer type="module" src="/src/main.js"></script>
-
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://api.tomtom.com/maps-sdk-for-web/cdn/6.x/6.25.0/maps/maps.css"
-    />
 
     <!-- Material CSS Icons -->
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
+    />
+
+    <link 
+      rel="preload" 
+      as="image" 
+      href="/assets/images/hero/hero-image2.png" 
+      type="image/png" 
+      fetchpriority="high" 
+    />
+
+
+    <link
+      rel="preload"
+      as="image"
+      href="/assets/images/hero/hero-illustration.png"
+      type="image/png"
     />
 
     <!-- JSON-LD structured data -->
@@ -83,7 +87,5 @@
     <script src="/Utilities/util.js"></script>
     <script src="/Utilities/main.js"></script>
     <script src="https://unpkg.com/boxicons@2.1.4/dist/boxicons.js"></script>
-    <script src="https://api.tomtom.com/maps-sdk-for-web/cdn/5.x/5.64.0/maps/maps-web.min.js"></script>
-    <script src="https://api.tomtom.com/maps-sdk-for-web/cdn/5.x/5.64.0/services/services-web.min.js"></script>
   </body>
 </html>

--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -7,19 +7,23 @@ const isTablet = ref(false);
 const isMobile = ref(false);
 const videoVisible = ref(false); // Lazy load flag
 
-// Check device type based on window width
+// Check device type
 const checkDeviceType = () => {
   const width = window.innerWidth;
   if (width >= 640 && width < 768) {
+    // Small devices (large phones)
     isTablet.value = false;
     isMobile.value = true;
   } else if (width >= 768 && width < 1024) {
+    // Medium devices (tablets)
     isTablet.value = true;
     isMobile.value = false;
   } else if (width >= 1024) {
+     // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
   } else {
+    // Extra small devices (phones)
     isTablet.value = false;
     isMobile.value = true;
   }

--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -19,7 +19,7 @@ const checkDeviceType = () => {
     isTablet.value = true;
     isMobile.value = false;
   } else if (width >= 1024) {
-     // Large devices (laptops/desktops)
+    // Large devices (laptops/desktops)
     isTablet.value = false;
     isMobile.value = false;
   } else {

--- a/src/pages/Impact/CollaboratingSchools/Map.vue
+++ b/src/pages/Impact/CollaboratingSchools/Map.vue
@@ -67,24 +67,78 @@ const loadCSS = (href) => {
 const addMarkers = (map) => {
   const tt = window.tt;
   const locations = [
-    { name: 'Alabama Institute for the Deaf and Blind', coordinates: [-86.121667, 33.423889] },
-    { name: 'Arizona State School for the Deaf and the Blind', coordinates: [-110.9904206, 32.2370163] },
-    { name: 'California School for the Blind', coordinates: [-121.965, 37.561389] },
-    { name: 'Florida School for the Deaf and the Blind', coordinates: [-81.31568, 29.91387] },
-    { name: 'Georgia Academy for the Blind', coordinates: [-83.6686, 32.8481] },
-    { name: 'Hadley (IL)', coordinates: [-87.7305, 42.1056] },
-    { name: 'Idaho Educational Services for the Deaf and the Blind', coordinates: [-114.71018377937226, 42.930033266556364] },
-    { name: 'Illinois School for the Visually Impaired', coordinates: [-90.21798754611584, 39.73565543633133] },
-    { name: 'Indiana School for the Blind and Visually Impaired', coordinates: [-86.08515046145114, 39.83401516509762] },
-    { name: 'Iowa Educational Services for the Blind and Visually Impaired', coordinates: [-95.82260501904825, 41.22588929543891] },
-    { name: 'Kansas State School for the Blind', coordinates: [-94.6395, 39.11653] },
-    { name: 'Kentucky School for the Blind', coordinates: [-85.713383, 38.255933] },
-    { name: 'Louisiana School for the Visually Impaired', coordinates: [-91.188055, 30.393055] },
-    { name: 'Maryland School for the Blind', coordinates: [-76.536111, 39.3675] },
-    { name: 'Missouri School for the Blind', coordinates: [-90.245, 38.608333] },
-    { name: 'Perkins School for the Blind (MA)', coordinates: [-71.1755, 42.362] },
-    { name: 'Vermont Association for the Blind and Visually Impaired', coordinates: [-73.15, 44.466667] },
-    { name: 'Visually Impaired Preschool Services (KY + IN)', coordinates: [-85.68384087502888, 38.20048802883136] }
+  {
+            name: 'Alabama Institute for the Deaf and Blind',
+            coordinates: [-86.121667, 33.423889],
+          },
+          {
+            name: 'Arizona State School for the Deaf and the Blind',
+            coordinates: [-110.9904206, 32.2370163],
+          },
+          {
+            name: 'California School for the Blind',
+            coordinates: [-121.965, 37.561389],
+          },
+          {
+            name: 'Florida School for the Deaf and the Blind',
+            coordinates: [-81.31568, 29.91387],
+          },
+          {
+            name: 'Georgia Academy for the Blind',
+            coordinates: [-83.6686, 32.8481],
+          },
+          {
+            name: 'Hadley (IL)',
+            coordinates: [-87.7305, 42.1056],
+          },
+          {
+            name: 'Idaho Educational Services for the Deaf and the Blind',
+            coordinates: [-114.71018377937226, 42.930033266556364],
+          },
+          {
+            name: 'Illinois School for the Visually Impaired',
+            coordinates: [-90.21798754611584, 39.73565543633133],
+          },
+          {
+            name: 'Indiana School for the Blind and Visually Impaired',
+            coordinates: [-86.08515046145114, 39.83401516509762],
+          },
+          {
+            name: 'Iowa Educational Services for the Blind and Visually Impaired',
+            coordinates: [-95.82260501904825, 41.22588929543891],
+          },
+          {
+            name: 'Kansas State School for the Blind',
+            coordinates: [-94.6395, 39.11653],
+          },
+          {
+            name: 'Kentucky School for the Blind',
+            coordinates: [-85.713383, 38.255933],
+          },
+          {
+            name: 'Louisiana School for the Visually Impaired',
+            coordinates: [-91.188055, 30.393055],
+          },
+          {
+            name: 'Maryland School for the Blind',
+            coordinates: [-76.536111, 39.3675],
+          },
+          {
+            name: 'Missouri School for the Blind',
+            coordinates: [-90.245, 38.608333],
+          },
+          {
+            name: 'Perkins School for the Blind (MA)',
+            coordinates: [-71.1755, 42.362],
+          },
+          {
+            name: 'Vermont Association for the Blind and Visually Impaired',
+            coordinates: [-73.15, 44.466667],
+          },
+          {
+            name: 'Visually Impaired Preschool Services (KY + IN)',
+            coordinates: [-85.68384087502888, 38.20048802883136],
+          },
   ];
 
   locations.forEach((location) => {

--- a/src/pages/Impact/CollaboratingSchools/Map.vue
+++ b/src/pages/Impact/CollaboratingSchools/Map.vue
@@ -1,122 +1,112 @@
-<script>
-import { onMounted, ref } from 'vue';
-
-export default {
-  name: 'Map',
-  setup() {
-    const mapRef = ref(null);
-    onMounted(() => {
-      const tt = window.tt;
-      var map = tt.map({
-        key: '1JNM9zmAHGoFlR8FiiV1syDoa05dafLP',
-        container: mapRef.value,
-        style: 'tomtom://vector/1/basic-main',
-        center: [-97.7431, 30.2672],
-        zoom: 2.5,
-      });
-      map.addControl(new tt.FullscreenControl());
-      map.addControl(new tt.NavigationControl());
-
-      addMarker(map);
-
-      function addMarker(map) {
-        const locations = [
-          {
-            name: 'Alabama Institute for the Deaf and Blind',
-            coordinates: [-86.121667, 33.423889],
-          },
-          {
-            name: 'Arizona State School for the Deaf and the Blind',
-            coordinates: [-110.9904206, 32.2370163],
-          },
-          {
-            name: 'California School for the Blind',
-            coordinates: [-121.965, 37.561389],
-          },
-          {
-            name: 'Florida School for the Deaf and the Blind',
-            coordinates: [-81.31568, 29.91387],
-          },
-          {
-            name: 'Georgia Academy for the Blind',
-            coordinates: [-83.6686, 32.8481],
-          },
-          {
-            name: 'Hadley (IL)',
-            coordinates: [-87.7305, 42.1056],
-          },
-          {
-            name: 'Idaho Educational Services for the Deaf and the Blind',
-            coordinates: [-114.71018377937226, 42.930033266556364],
-          },
-          {
-            name: 'Illinois School for the Visually Impaired',
-            coordinates: [-90.21798754611584, 39.73565543633133],
-          },
-          {
-            name: 'Indiana School for the Blind and Visually Impaired',
-            coordinates: [-86.08515046145114, 39.83401516509762],
-          },
-          {
-            name: 'Iowa Educational Services for the Blind and Visually Impaired',
-            coordinates: [-95.82260501904825, 41.22588929543891],
-          },
-          {
-            name: 'Kansas State School for the Blind',
-            coordinates: [-94.6395, 39.11653],
-          },
-          {
-            name: 'Kentucky School for the Blind',
-            coordinates: [-85.713383, 38.255933],
-          },
-          {
-            name: 'Louisiana School for the Visually Impaired',
-            coordinates: [-91.188055, 30.393055],
-          },
-          {
-            name: 'Maryland School for the Blind',
-            coordinates: [-76.536111, 39.3675],
-          },
-          {
-            name: 'Missouri School for the Blind',
-            coordinates: [-90.245, 38.608333],
-          },
-          {
-            name: 'Perkins School for the Blind (MA)',
-            coordinates: [-71.1755, 42.362],
-          },
-          {
-            name: 'Vermont Association for the Blind and Visually Impaired',
-            coordinates: [-73.15, 44.466667],
-          },
-          {
-            name: 'Visually Impaired Preschool Services (KY + IN)',
-            coordinates: [-85.68384087502888, 38.20048802883136],
-          },
-        ];
-
-        const tt = window.tt;
-        locations.forEach((location) => {
-          let marker = new tt.Marker()
-            .setLngLat(location.coordinates)
-            .addTo(map);
-          let popup = new tt.Popup({
-            offset: 25,
-            closeButton: false,
-          }).setText(location.name);
-          marker.setPopup(popup);
-        });
-      }
-    });
-
-    return { mapRef };
-  },
-};
-</script>
-
 <template>
-  <div id="map" ref="mapRef"></div>
+  <div id="map" ref="mapRef">
+    <p v-if="!mapVisible" class="text-center text-sm text-gray-500 mt-4">
+      Loading map...
+    </p>
+  </div>
 </template>
+
+<script setup>
+import { onMounted, onUnmounted, ref } from 'vue';
+
+const mapRef = ref(null);
+const mapVisible = ref(false);
+let observer;
+
+const onMapIntersect = (entries) => {
+  const [entry] = entries;
+  if (entry.isIntersecting) {
+    mapVisible.value = true;
+    loadMap();
+    observer.disconnect();
+  }
+};
+
+const loadMap = async () => {
+  if (!window.tt) {
+    // Load TomTom JS
+    await loadScript('https://api.tomtom.com/maps-sdk-for-web/cdn/5.x/5.64.0/maps/maps-web.min.js');
+    await loadScript('https://api.tomtom.com/maps-sdk-for-web/cdn/5.x/5.64.0/services/services-web.min.js');
+    // Load CSS
+    loadCSS('https://api.tomtom.com/maps-sdk-for-web/cdn/6.x/6.25.0/maps/maps.css');
+  }
+
+  const tt = window.tt;
+  const map = tt.map({
+    key: '1JNM9zmAHGoFlR8FiiV1syDoa05dafLP',
+    container: mapRef.value,
+    style: 'tomtom://vector/1/basic-main',
+    center: [-97.7431, 30.2672],
+    zoom: 2.5,
+  });
+
+  map.addControl(new tt.FullscreenControl());
+  map.addControl(new tt.NavigationControl());
+  addMarkers(map);
+};
+
+const loadScript = (src) => {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+};
+
+const loadCSS = (href) => {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  link.type = 'text/css';
+  document.head.appendChild(link);
+};
+
+const addMarkers = (map) => {
+  const tt = window.tt;
+  const locations = [
+    { name: 'Alabama Institute for the Deaf and Blind', coordinates: [-86.121667, 33.423889] },
+    { name: 'Arizona State School for the Deaf and the Blind', coordinates: [-110.9904206, 32.2370163] },
+    { name: 'California School for the Blind', coordinates: [-121.965, 37.561389] },
+    { name: 'Florida School for the Deaf and the Blind', coordinates: [-81.31568, 29.91387] },
+    { name: 'Georgia Academy for the Blind', coordinates: [-83.6686, 32.8481] },
+    { name: 'Hadley (IL)', coordinates: [-87.7305, 42.1056] },
+    { name: 'Idaho Educational Services for the Deaf and the Blind', coordinates: [-114.71018377937226, 42.930033266556364] },
+    { name: 'Illinois School for the Visually Impaired', coordinates: [-90.21798754611584, 39.73565543633133] },
+    { name: 'Indiana School for the Blind and Visually Impaired', coordinates: [-86.08515046145114, 39.83401516509762] },
+    { name: 'Iowa Educational Services for the Blind and Visually Impaired', coordinates: [-95.82260501904825, 41.22588929543891] },
+    { name: 'Kansas State School for the Blind', coordinates: [-94.6395, 39.11653] },
+    { name: 'Kentucky School for the Blind', coordinates: [-85.713383, 38.255933] },
+    { name: 'Louisiana School for the Visually Impaired', coordinates: [-91.188055, 30.393055] },
+    { name: 'Maryland School for the Blind', coordinates: [-76.536111, 39.3675] },
+    { name: 'Missouri School for the Blind', coordinates: [-90.245, 38.608333] },
+    { name: 'Perkins School for the Blind (MA)', coordinates: [-71.1755, 42.362] },
+    { name: 'Vermont Association for the Blind and Visually Impaired', coordinates: [-73.15, 44.466667] },
+    { name: 'Visually Impaired Preschool Services (KY + IN)', coordinates: [-85.68384087502888, 38.20048802883136] }
+  ];
+
+  locations.forEach((location) => {
+    const marker = new tt.Marker().setLngLat(location.coordinates).addTo(map);
+    const popup = new tt.Popup({ offset: 25, closeButton: false }).setText(location.name);
+    marker.setPopup(popup);
+  });
+};
+
+onMounted(() => {
+  observer = new IntersectionObserver(onMapIntersect, {
+    root: null,
+    threshold: 0.3,
+  });
+
+  if (mapRef.value) observer.observe(mapRef.value);
+});
+
+onUnmounted(() => {
+  if (observer) observer.disconnect();
+});
+</script>
 
 <style>
 #map {

--- a/vercel.json
+++ b/vercel.json
@@ -79,5 +79,25 @@
       "source": "/(.*)",
       "destination": "/"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)\\.(js|css|woff2?|ttf|eot|svg|png|jpg|jpeg|gif|webp|avif|ico)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Reference

- This PR addresses issues in [issue 185](https://github.com/Crustaly/audemywebsite/issues/185)

Problem
Audemy website reported had a slow load time both on the initial page load and when navigating between routes. Lighthouse audit highlighted the following performance issues:
- Large image/video files delaying Largest Contentful Paint (LCP)
- Unoptimized asset delivery and lack of caching
- Render-blocking resources and excessive JavaScript/CSS

Approach
To improve the site's perceived and actual load speed, the following actions were implemented:
- Lazy Loading: Deferred loading of heavy assets like video and maps, which previously delayed rendering by up to 400ms.
- Preloading LCP Images: Explicitly preloaded the Largest Contentful Paint (LCP) image to ensure it's prioritized during rendering.
- Vercel Caching Configuration: Updated vercel.json to define proper caching strategies for static assets and dynamic routes.
- General Best Practices:
Minimized unnecessary JavaScript and CSS where possible.

Before
- LCP ~1.8s
- Page often blank for 5–10 seconds on slower networks
- 400ms delay from video load

After
- LCP improved, consistently under 2s
- Smoother route transitions
- Lower bandwidth usage on repeated visits due to caching

Lighthouse reports:
- Before
[lighthouse-report-before.pdf](https://github.com/user-attachments/files/20558108/lighthouse-report-before.pdf)

- After
[download.pdf](https://github.com/user-attachments/files/20558110/download.pdf)

Future Work
- Reduced layout shifts by adding explicit width/height attributes to images.
- Initiated conversion of images to next-gen formats (WebP or AVIF)
- Further optimize and tree-shake JavaScript bundles