### PR TITLE
PR: Add 2-Second Delay on Recording button

### DIFF
--- a/src/Utilities/recordAudio.js
+++ b/src/Utilities/recordAudio.js
@@ -31,7 +31,7 @@ export const recordAudio = (onStart, onStop) => {
         setTimeout(() => {
           mediaRecorder.stop();
           stream.getTracks().forEach((track) => track.stop());
-        }, 5000); // Adjust duration as needed
+        }, 7000); // Adjust duration as needed
       })
       .catch((err) => {
         reject(`Error accessing microphone: ${err.message}`);

--- a/src/components/Game/GameControls.vue
+++ b/src/components/Game/GameControls.vue
@@ -68,20 +68,20 @@
   </div>
 
   <div
-    v-show="showControls && !isRecording"
+    v-show="showControls && isRecording"
     id="transcript"
     class="text-center text-xl font-bold pt-2 pb-1"
   >
-    Transcription will take place {{ transcription }}
+    Your Answer {{ transcription }}
   </div>
 
-  <div
+  <!-- <div
     v-show="showControls && !isRecording"
     id="final-transcript"
     class="text-center text-xl font-bold pt-2 pb-1 text-green-700"
   >
     Final Transcription: {{ finalTranscript }}
-  </div>
+  </div> -->
 </template>
 
 <script setup>

--- a/src/components/Game/GameControls.vue
+++ b/src/components/Game/GameControls.vue
@@ -5,8 +5,8 @@
       isTablet
         ? 'flex gap-[25px] mb-6'
         : isMobile
-          ? 'flex flex-col gap-4 mb-6'
-          : 'flex gap-6 mb-6',
+        ? 'flex flex-col gap-4 mb-6'
+        : 'flex gap-6 mb-6',
     ]"
   >
     <button
@@ -21,8 +21,8 @@
           isRecording
             ? 'Stop Recording'
             : isTablet || isMobile
-              ? 'Record'
-              : 'Record Answer'
+            ? 'Record'
+            : 'Record Answer'
         }}
       </span>
       <img
@@ -39,8 +39,8 @@
         isTablet
           ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
           : isMobile
-            ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
-            : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+          ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+          : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
         'bg-white border border-[#0096D6] text-[#0096D6]',
         isIntroPlaying || isButtonCooldown
           ? 'opacity-50 cursor-not-allowed'
@@ -52,8 +52,8 @@
         isIntroPlaying
           ? 'Please wait until the introduction finishes'
           : isButtonCooldown
-            ? 'Please wait before repeating the question again'
-            : 'Repeat the current question'
+          ? 'Please wait before repeating the question again'
+          : 'Repeat the current question'
       "
     >
       <span class="text-lg font-medium">{{
@@ -68,11 +68,11 @@
   </div>
 
   <div
-    v-show="showControls"
+    v-show="showControls && !isRecording"
     id="transcript"
     class="text-center text-xl font-bold pt-2 pb-1"
   >
-    You said: {{ transcription }}
+    Transcription will take place {{ transcription }}
   </div>
 </template>
 
@@ -108,6 +108,10 @@ const props = defineProps({
     type: Number,
     required: true,
   },
+  finalTranscript1: {
+    type: String,
+    required: true,
+  },
 });
 
 const showControls = computed(() => {
@@ -128,8 +132,8 @@ const recordButtonClasses = computed(() => [
   props.isTablet
     ? 'w-[200px] h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
     : props.isMobile
-      ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
-      : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
+    ? 'w-full h-[60px] pt-5 pr-[30px] pb-5 pl-[30px] gap-[10px] rounded-[20px]'
+    : 'gap-2.5 w-[234px] h-[116px] pt-5 pr-7 pb-5 pl-7 rounded-[20px]',
   props.isRecording ? 'bg-red-500' : 'bg-[#087BB4]',
   'text-white',
   isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
@@ -142,6 +146,8 @@ const recordButtonTitle = computed(() => {
     return 'Please wait until the question finishes playing';
   return 'Record your answer';
 });
+
+// console.log('Final Transcript:', finalTranscript1.value);
 
 const onRecordClick = () => {
   emits('record-click');

--- a/src/components/Game/GameControls.vue
+++ b/src/components/Game/GameControls.vue
@@ -74,6 +74,14 @@
   >
     Transcription will take place {{ transcription }}
   </div>
+
+  <div
+    v-show="showControls && !isRecording"
+    id="final-transcript"
+    class="text-center text-xl font-bold pt-2 pb-1 text-green-700"
+  >
+    Final Transcription: {{ finalTranscript }}
+  </div>
 </template>
 
 <script setup>
@@ -108,7 +116,7 @@ const props = defineProps({
     type: Number,
     required: true,
   },
-  finalTranscript1: {
+  finalTranscript: {
     type: String,
     required: true,
   },

--- a/src/composables/useGameCore.js
+++ b/src/composables/useGameCore.js
@@ -129,6 +129,8 @@ export function useGameCore(gameConfig) {
         console.log('User Answer:', finalTranscript);
         console.log('Correct Answer:', question['A']);
 
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
         const isCorrect = validateAnswer(finalTranscript, question);
 
         if (isCorrect) {

--- a/src/composables/useGameCore.js
+++ b/src/composables/useGameCore.js
@@ -18,6 +18,7 @@ export function useGameCore(gameConfig) {
   const score = ref(0);
   const isRecording = ref(false);
   const transcription = ref('');
+  const finalTranscript = ref('');
   const micStartTime = ref(null);
 
   const playButton = ref(false);
@@ -125,16 +126,16 @@ export function useGameCore(gameConfig) {
         isButtonCooldown.value = true;
         console.log('Processing recording...');
 
-        const finalTranscript = transcription.value;
+        finalTranscript.value = transcription.value;
 
         const question = questionsDb.value[randQueNum[numOfAudiosPlayed.value]];
         console.log('Question is: ', question['Q']);
-        console.log('User Answer:', finalTranscript);
+        console.log('User Answer:', finalTranscript.value);
         console.log('Correct Answer:', question['A']);
 
         await new Promise((resolve) => setTimeout(resolve, 2000));
 
-        const isCorrect = validateAnswer(finalTranscript, question);
+        const isCorrect = validateAnswer(finalTranscript.value, question);
 
         if (isCorrect) {
           score.value++;
@@ -256,6 +257,7 @@ export function useGameCore(gameConfig) {
     score,
     isRecording,
     transcription,
+    finalTranscript,
     playButton,
     isIntroPlaying,
     isButtonCooldown,

--- a/src/composables/useGameCore.js
+++ b/src/composables/useGameCore.js
@@ -18,6 +18,7 @@ export function useGameCore(gameConfig) {
   const score = ref(0);
   const isRecording = ref(false);
   const transcription = ref('');
+  const micStartTime = ref(null);
 
   const playButton = ref(false);
   const isIntroPlaying = ref(false);
@@ -114,6 +115,8 @@ export function useGameCore(gameConfig) {
     if (numOfAudiosPlayed.value < 5 && !isIntroPlaying.value) {
       if (!isRecording.value) {
         isRecording.value = true;
+        micStartTime.value = Date.now();
+        console.log('Mic started at:', new Date(micStartTime.value).toLocaleTimeString());
 
         startListening((transcript) => {
           transcription.value = transcript;
@@ -150,6 +153,12 @@ export function useGameCore(gameConfig) {
 
         stopListening();
         isRecording.value = false;
+        if (micStartTime.value) {
+          const micEndTime = Date.now();
+          const micDurationSeconds = ((micEndTime - micStartTime.value) / 1000).toFixed(2);
+          console.log(`Mic was on for ${micDurationSeconds} seconds`);
+          micStartTime.value = null;
+        }
         numOfAudiosPlayed.value++;
 
         const isGameOver = numOfAudiosPlayed.value >= 5;

--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -39,6 +39,7 @@
           :isIntroPlaying="isIntroPlaying"
           :isButtonCooldown="isButtonCooldown"
           :transcription="transcription"
+          :finalTranscript="finalTranscript"
           :numOfAudiosPlayed="numOfAudiosPlayed"
           @record-click="toggleRecording"
           @repeat-click="repeatQuestion"
@@ -68,6 +69,7 @@ const {
   score,
   isRecording,
   transcription,
+  finalTranscript,
   playButton,
   isIntroPlaying,
   isButtonCooldown,


### PR DESCRIPTION
# PR: Add 2-Second Delay on Recording button

## Changes

- Fixed UX issue where the player could immediately proceed after a wrong answer, potentially skipping the spoken correct answer.
- Added a 2-second delay after the correct answer audio is played in the `toggleRecording` function in `useGameCore.js`.

## Details

When the user's answer is incorrect:
- `incorrectaudio.mp3` is played.
- Then, the correct answer is spoken using `playQuestion(...)`.
- **Now added**: A `setTimeout`-style delay using:

  ```js
  await new Promise(resolve => setTimeout(resolve, 2000));
This ensures a short pause before progressing to the next question.

## Why This Fix?

> “Player waits for the screen to show the answer before pressing Stop.”

- Improves pacing and user comprehension.
- Ensures players hear the correct answer fully before the game advances.
- Especially helpful for auditory learners and accessibility.