### PR TITLE
feat: add password toggle & length validation to auth forms

### DIFF
--- a/src/components/AccountPages/PasswordToggle.vue
+++ b/src/components/AccountPages/PasswordToggle.vue
@@ -1,0 +1,78 @@
+<script setup>
+/* PasswordToggle.vue
+ *
+ * - Reusable button to show/hide password input (icon + label)
+ * - Used in Login, Sign Up, and Reset Password forms
+ *
+ * - Emits 'password-toggle' event:
+ *    - Auth forms handles with matching @password-toggle
+ *    - Since props are read-only
+ *
+ * - Responsive layout:
+ *    - Outer button: flex
+ *    - Inner span: 2-column grid for left-aligned icon + label on auth forms
+ */
+
+const props = defineProps({
+  showPassword: {
+    type: Boolean,
+    required: true,
+    default: true,
+  },
+});
+
+const emit = defineEmits(['password-toggle']);
+</script>
+
+<template>
+  <button
+    type="button"
+    @click="emit('password-toggle')"
+    class="password-toggle-button grid grid-cols-[auto_auto]"
+  >
+    <span class="password-toggle-flex col-start-1">
+      <!-- Show eye icon when password is hidden -->
+      <span v-if="!showPassword" aria-hidden="true" class="mr-4 inline-block">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          class="bi bi-eye"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8M1.173 8a13 13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5s3.879 1.168 5.168 2.457A13 13 0 0 1 14.828 8q-.086.13-.195.288c-.335.48-.83 1.12-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5s-3.879-1.168-5.168-2.457A13 13 0 0 1 1.172 8z"
+          />
+          <path
+            d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5M4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0"
+          />
+        </svg>
+      </span>
+      <!-- Show slashed eye icon when password is visible -->
+      <span v-else aria-hidden="true" class="mr-4 inline-block">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          class="bi bi-eye-slash"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7 7 0 0 0-2.79.588l.77.771A6 6 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13 13 0 0 1 14.828 8q-.086.13-.195.288c-.335.48-.83 1.12-1.465 1.755q-.247.248-.517.486z"
+          />
+          <path
+            d="M11.297 9.176a3.5 3.5 0 0 0-4.474-4.474l.823.823a2.5 2.5 0 0 1 2.829 2.829zm-2.943 1.299.822.822a3.5 3.5 0 0 1-4.474-4.474l.823.823a2.5 2.5 0 0 0 2.829 2.829"
+          />
+          <path
+            d="M3.35 5.47q-.27.24-.518.487A13 13 0 0 0 1.172 8l.195.288c.335.48.83 1.12 1.465 1.755C4.121 11.332 5.881 12.5 8 12.5c.716 0 1.39-.133 2.02-.36l.77.772A7 7 0 0 1 8 13.5C3 13.5 0 8 0 8s.939-1.721 2.641-3.238l.708.709zm10.296 8.884-12-12 .708-.708 12 12z"
+          />
+        </svg>
+      </span>
+      <span>
+        {{ showPassword ? 'Hide password' : 'Show password' }}
+      </span>
+    </span>
+  </button>
+</template>

--- a/src/form-style.css
+++ b/src/form-style.css
@@ -1,3 +1,17 @@
+/*
+ * form-style.css: Shared Tailwind classes for auth forms and password toggle and checklist (WIP)
+ * 
+ * Relevant files (.vue):
+ * - LogIn (including School form)
+ * - SignUp, 
+ * - ForgotPassword, ResetLinkSent,
+ * - ResetLandingPage, ResetPassword, ResetConfirm
+ * - NotFound
+ * 
+ * Relevant Components:
+ * - PasswordToggle & (WIP) PasswordChecklist
+ */
+
 @layer components {
   /* --- General Page & Form Structure --- */
   .page-container {
@@ -59,6 +73,17 @@
   }
   .form-hint {
     @apply text-left w-full mb-5;
+  }
+
+  /* --- Password Visibility Toggle --- */
+  .password-toggle-button {
+    /* Align styling and hover effects with Google OAuth button */
+    @apply h-[35px] w-auto rounded-lg border border-gray-300 px-2 hover:bg-[#e6ebf8] hover:border-[#d5e3fa];
+  }
+
+  .password-toggle-flex {
+    /* Layout container for Show/Hide Password icon + label */
+    @apply inline-flex items-center cursor-pointer;
   }
 
   /* --- Misc --- */

--- a/src/pages/LogIn/LogIn.vue
+++ b/src/pages/LogIn/LogIn.vue
@@ -30,7 +30,7 @@
         </div>
         <!-- EMAIL FIELD -->
         <div>
-          <label class="form-label" for="email"> Email Address </label>
+          <label class="form-label" for="email">Email Address</label>
           <input
             v-model="email"
             type="email"
@@ -55,21 +55,29 @@
           </div>
           <input
             v-model="password"
-            type="password"
+            :type="showPassword ? 'text' : 'password'"
             class="form-input-full"
             id="password"
             name="password"
             placeholder="Enter your password"
+            minlength="8"
+            maxlength="15"
+          />
+          <!-- TOGGLE PASSWORD VISIBILITY -->
+          <PasswordToggle
+            :showPassword="showPassword"
+            @password-toggle="showPassword = !showPassword"
+            class="mb-0"
           />
         </div>
         <!-- OPTIONAL SIGN UP GRID -->
         <div class="auth-grid">
           <p class="auth-grid-caption">New to Audemy?</p>
           <div class="auth-grid-link">
-            <a href="signup" class="auth-link"> Sign Up </a>
+            <a href="signup" class="auth-link">Sign Up</a>
           </div>
         </div>
-        <!-- GET STARTED BTN -->
+        <!-- LOGIN BUTTON -->
         <div class="form-action-container">
           <button type="submit" class="secondary-button">Log in</button>
         </div>
@@ -110,7 +118,7 @@
         </div>
         <!-- SCHOOL NAME FIELD -->
         <div id="school-form">
-          <label for="school" class="form-label"> School </label>
+          <label for="school" class="form-label">School</label>
           <input
             v-model="school"
             type="text"
@@ -135,6 +143,7 @@ import Header from '../../components/Header/Header.vue';
 import Footer from '../../components/Footer/Footer.vue';
 import ScrollUpButton from '../../components/ScrollUpButton/ScrollUpButton.vue';
 import Banner from '../../components/AccountPages/Banner.vue';
+import PasswordToggle from '../../components/AccountPages/PasswordToggle.vue';
 
 import { ref, onMounted } from 'vue';
 import { GoogleLogin } from 'vue3-google-login';
@@ -150,6 +159,7 @@ const userSession = ref(null);
 const userProfile = ref(null);
 const school = ref(''); // Store school input
 const showSchoolForm = ref(false); // Control form visibility
+const showPassword = ref(false); // Toggle password visibility
 const isLoading = ref(false); // For loading state
 const router = useRouter();
 var OAuthResponse = ref(null);

--- a/src/pages/ResetPassword/ResetPassword.vue
+++ b/src/pages/ResetPassword/ResetPassword.vue
@@ -2,6 +2,7 @@
 import Banner from '../../components/AccountPages/Banner.vue';
 import Header from '../../components/Header/Header.vue';
 import Footer from '../../components/Footer/Footer.vue';
+import PasswordToggle from '../../components/AccountPages/PasswordToggle.vue';
 
 import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
@@ -9,6 +10,7 @@ import { useRouter } from 'vue-router';
 var linkExpired = ref(false); // flag for link expired error on frontend
 const password = ref('');
 const confirmPassword = ref('');
+const showPassword = ref(false); // Toggle password visibility
 const token = ref('');
 const router = useRouter();
 const isLoading = ref(false); // For loading state
@@ -155,11 +157,13 @@ const resetConfirm = async (event) => {
           <label for="password" class="form-label"> Password </label>
           <input
             v-model="password"
-            type="password"
+            :type="showPassword ? 'text' : 'password'"
             class="form-input-full"
             id="password"
             name="password"
             placeholder="Create your best password"
+            minlength="8"
+            maxlength="15"
           />
         </div>
         <!-- HINT MESSAGES FOR PASSWORD -->
@@ -178,13 +182,21 @@ const resetConfirm = async (event) => {
           </label>
           <input
             v-model="confirmPassword"
-            type="password"
+            :type="showPassword ? 'text' : 'password'"
             class="form-input-full"
             id="confirm_password"
             name="confirm_password"
             placeholder="Confirm your password"
+            minlength="8"
+            maxlength="15"
           />
         </div>
+        <!-- TOGGLE PASSWORD VISIBILITY -->
+        <PasswordToggle
+          :showPassword="showPassword"
+          @password-toggle="showPassword = !showPassword"
+          class="mb-8"
+        />
         <!-- ERROR MESSAGES FOR PASSWORD CONFIRMATION -->
         <div class="form-hint" v-if="errors">
           <div role="alert" class="text-red-700">


### PR DESCRIPTION
## $\color{Emerald}{Reference}$  
- This PR implements the Password Visibility Toggle in [Issue #162](https://github.com/Crustaly/audemywebsite/issues/162)

---

##  $\color{Emerald}{Summary}$ 

| Files / Components                                | Changes                                                                 |
|--------------------------------------------|--------------------------------------------------------------------------|
| `LogIn.vue`<br>`SignUp.vue`<br>`ResetPassword.vue`      | - Reusable, responsive, accessible password visibility toggle  <br> - Enforced input `minlength=8` & `maxlength=15` |
| `SignUp.vue`<br>(only) | - Improved password feedback (user, error, debug) for Sign Up<br>- Minor accessibility fixes |
| +`<PasswordToggle />` | - New reusable component |
| `form-style.css`                            | - Added Tailwind classes for password toggle RWD and styling consistency |

---

## $\color{Emerald}{Problem}$ 

- **Log In, Sign Up, and Reset Password forms:**
  - Lacked password visibility toggle  
    - Accessibility/usability issue  
    - Does not accommodate Audemy's users, such as:  
      - Children, who may struggle with verifying passwords  
      - Sighted users (teachers, developers during testing)  
  - Unenforced min/max password length limits  
    - Allowed weak or excessively long passwords  
    - Inconsistent validation (only Reset Password enforced/checked for password length) 

---

## $\color{Emerald}{Approach}$ 

### 1. Reusable Component: `<PasswordToggle />`

<details>
  <summary><i>View details</i></summary>

- Created reusable password visibility toggle for DRYer code 
- Accepts `showPassword` as a `prop`
  - Emits `password-toggle` event (since we cannot modify props directly in Vue)
- **Responsive layout:**
  - Outer `<button>`: simple flex layout
  - Inner `<span>`: 2-column grid for icon/label left alignment
- **Dynamic toggle rendering:**
  - Updates label + icon based on `showPassword` flag

</details>

---

### 2. Password Validation Improvements 

<details>
  <summary><i>View details</i></summary>

- Enforced `minlength=8` and `maxlength=15` across all 3 auth forms:
  - Prevents weak or overly long passwords
  - Helps standardize PW length requirements
  - Improves account security and database storage

    | **Sign Up Context & Audience**            | **Message**                                                                 |
    |----------------------------------|----------------------------------------------------------------------------------|
    | **Typing**: `feedbackMessage` (user)       | <kbd>Oops! Passwords match but are too short. Use at least 8 characters.</kbd>   |
    | **Submission:** `errorMessage` (user) | <kbd>Passwords match but are too short. Please create a stronger password.</kbd>|
    | **Submission**: `debugMessage` (devs)  | <kbd>Form submission stopped: password length is less than 8</kbd>               |

</details>

---

### 3. Password Toggle & Validation: Accessibility

> [!NOTE]
> Although the focus of this PR is the `<PasswordToggle />` feature and length validation, I decided to include the minor accessibility changes as well, since they were closely related and affected the same files (in scope).

<details>
  
  <summary><i>View details</i></summary>

#### 3a. Password Toggle UI 
- Set `aria-hidden="true"` for decorative "eye" icons
- Corrected button semantics in Sign Up: `<button type="button" ...>` → `<button type="submit" ...>`
- UI affordance:
  - Styled to align with the <kbd>Google OAuth</kbd> button and its hover effects
- (For reference:)
  - <kbd>tab</kbd>: Focus
  - <kbd>space</kbd>: Toggle visibility
  - <kbd>Enter</kbd>: Submit form

#### 3b. Sign Up: Password Feedback
- **Updated `feedbackMessage`:**
  - Removed `role="alert"` and added `aria-hidden="true"` to prevent screen reader interruptions while typing
  - Live feedback (aka password match status) remains visible to sighted users
- **Updated `errorMessage` logic and message:**
  - Error feedback is now announced once upon form submission (mute live output if user is still typing)

</details>

---

## $\color{Emerald}{Demos}$

### a. Password Toggle UI

<details>
  <summary><i>Log In & Reset Password (Screenshots)</i></summary>

| **Log In** | **Reset Password** |
|------------|--------------------|
|  <img width="500" alt="show password login" src="https://github.com/user-attachments/assets/a21ca2b7-914f-4947-9f03-1c14ec1baa88" /> |  <img width="500" alt="reset password page pw toggle" src="https://github.com/user-attachments/assets/37e6a840-195f-498f-9b16-de26607b34fd" /> |

</details>

<details>
  <summary><i>Sign Up (Live Demo – dynamic rendering + hover effects)</i></summary>

| **Password Toggle (Video)** |
|-----------------------------|
| <video controls width="300" src="https://github.com/user-attachments/assets/7ab1eac2-84dd-489b-8c17-e5c7ea9bc633"></video> |

</details>

---

### b. Sign Up: Updated Password Feedback

<details>
  <summary><i>View Demos</i></summary>

| Live Feedback (Typing in Progress) | Error Feedback (On Form Submission) | 
|:----------------------------------:|:----------------------------------:|
| <i>Sighted users can still see the live, muted feedback for PW match status.</i><br><img width="500" alt="updated signup feedback short pw but matching" src="https://github.com/user-attachments/assets/99ec2179-e38b-41b3-aef7-1fa0baf2b4d5" /> | <i>Single error feedback announced once on form submission (5 seconds).</i><br><img width="500" alt="too short signup pws" src="https://github.com/user-attachments/assets/f4a915a3-d58b-4bbb-ae75-ea498fb61bd6" />  |

</details>

---

## $\color{Emerald}{Manual}$ $\color{Emerald}{Tests}$ 

<details>
<summary><i>Test cases</i></summary>

### a. Auth Forms Functionality

| Log In        | Sign Up   | Reset Password |
|---------------|-----------|----------------|
| Email login   | Email signup | Valid reset link |
| Google login → School Form  | Google signup → School Form | Expired reset link | 
| Reused reset password<br>(after creating account via Log In/Sign Up) | --- | --- | 

---

### b. Accessibility Tests

| Tool used        | What was checked |
|---------------------------|------------------|
| **Lighthouse Audit**      | - No accessibility issues reported in the updated Log In, Sign Up, and Reset Password pages |
| **VoiceOver**             | - Decorative eye icons are not announced<br>- Password toggle is tabbable and toggleable<br>- Live password feedback is muted, as expected<br>- Single error feedback/output on form submission |

</details>

---

## $\color{Emerald}{Future}$ $\color{Emerald}{Improvements}$ 

- **WIP**: Dynamic Password Checklist for Sign Up and Reset Password forms (Part 2 of [Issue #162](https://github.com/Crustaly/audemywebsite/issues/162))
- **Reset Password:** Replace inline, color-coded text → message box (UI consistency)  
- **Refactor:** Repeated feedback styles → reusable classes 
- **Enhancement:** fade effects for feedback