### PR TITLE
Fixed Typo in pages

### DIFF
--- a/src/pages/Home/Impact/Impact.vue
+++ b/src/pages/Home/Impact/Impact.vue
@@ -66,7 +66,7 @@ import Globe from '/assets/images/impact/globe 1.svg';
             36
           </h1>
           <p class="font-poppins text-base text-center mobile:text-[12px]">
-            parntering <br />
+            partnering <br />
             schools
           </p>
         </div>

--- a/src/pages/Impact/OurReach/OurReach.vue
+++ b/src/pages/Impact/OurReach/OurReach.vue
@@ -59,7 +59,7 @@
             36
           </h1>
           <p class="font-poppins text-base text-center mobile:text-[12px]">
-            parntering <br />
+            partnering <br />
             schools
           </p>
         </div>

--- a/src/pages/Impact/PressList/PressList.vue
+++ b/src/pages/Impact/PressList/PressList.vue
@@ -47,7 +47,7 @@ const items = [
   },
   {
     image: 'points-of-light.png',
-    text: 'Championing Accessibility in Education for Blind and Visually Impaired Students Championing',
+    text: 'Championing Accessibility in Education for Blind and Visually Impaired Students.',
     network: 'Points of Light',
     url: 'https://www.pointsoflight.org/awards/championing-accessibility-in-education-for-blind-and-visually-impaired-students/',
   },


### PR DESCRIPTION
## Summary

1. **Typo (Home & Impact pages)**  
   - “36 parntering schools” → should be **“36 partnering schools”**  
   - Affected Files:
     - `src/pages/Impact/OurReach/OurReach.vue`
     - `src/pages/Home/Impact/Impact.vue`

2. **Title Fix (Home & Press & Recognition pages)**  
   - Remove extra **“Championing”** at the end of the title for correct grammar and to match the official, linked source  
   - Reference: [Points of Light – Championing Accessibility in Education for Blind and Visually Impaired Students](https://www.pointsoflight.org/awards/championing-accessibility-in-education-for-blind-and-visually-impaired-students/)

   <br>
   
    | Typo in "Home" & "Impact" <br>(Stats Card) | Typo in "Home" & "Press & Reco." <br>("Points of Light" Card) |
    | :---: | :---: |
    |  <img width="192" height="193" alt="Screenshot 2025-07-28 at 11 40 24 AM" src="https://github.com/user-attachments/assets/e7a64d99-e11a-4177-a36b-48ca6a68d875" /> |  <img width="275" height="385" alt="Screenshot 2025-07-28 at 1 25 51 PM" src="https://github.com/user-attachments/assets/a7a12da0-a82a-47c5-9f79-818424189bbe" /> |

---
## Status
Both the typos has been fixed and manually tested.
<details>

| Typo in Home | Typo in press rec
| :---: | :---: |
| <img width="209" height="164" alt="Screenshot 2025-07-29 at 7 53 26 AM" src="https://github.com/user-attachments/assets/c403b8c5-aa13-4f54-b547-a454e05cfed1" /> | <img width="295" height="89" alt="Screenshot 2025-07-29 at 7 53 35 AM" src="https://github.com/user-attachments/assets/110403fb-cf0d-404e-a309-e5952ab51a72" />
</details>


> Reference: https://github.com/Crustaly/audemywebsite/pull/224#pullrequestreview-3064580482