### PR TITLE
feat: Add Responsive "Terms of Use" (Footer Page)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -21,6 +21,7 @@ Disallow: /reset-confirm
 Disallow: /reset-landing-page
 Disallow: /accessibility-statement
 Disallow: /privacy-policy
+Disallow: /terms-of-use
 
 Disallow: /*.env$
 Disallow: /*.log$

--- a/src/components/AccountPages/Banner.vue
+++ b/src/components/AccountPages/Banner.vue
@@ -10,8 +10,6 @@ import Glasses from '/assets/images/impact/glasses.svg';
 import { useDeviceType } from '../../Utilities/checkDeviceType';
 const { isMobile, isTablet } = useDeviceType();
 
-// import { defineProps } from 'vue';
-
 // isImageWide: true if image width > height.
 // Helps Banner scale image: Reduces width for wide images, or height for tall ones.
 const props = defineProps({
@@ -169,5 +167,3 @@ const props = defineProps({
     </div>
   </div>
 </template>
-
-<style scoped></style>

--- a/src/components/Footer/Footer.vue
+++ b/src/components/Footer/Footer.vue
@@ -260,9 +260,15 @@ const socialMediaGridClasses = [
         <ul class="md:flex md:flex-row md:gap-10 md:justify-center">
           <!-- Copyright -->
           <li class="ftr-bio">&copy; 2024 Audemy</li>
+          <!-- Accessibility Statement -->
           <li class="ftr-subtext">
             <a href="/accessibility-statement">Accessibility Statement</a>
           </li>
+          <!-- Terms of Use -->
+          <li class="ftr-subtext">
+            <a href="/terms-of-use">Terms of Use</a>
+          </li>
+          <!-- Privacy Policy -->
           <li class="ftr-subtext">
             <a href="/privacy-policy">Privacy Policy</a>
           </li>

--- a/src/pages/Footer/PrivacyPolicy.vue
+++ b/src/pages/Footer/PrivacyPolicy.vue
@@ -11,7 +11,7 @@ import Footer from '../../components/Footer/Footer.vue';
   <div class="content-container lg:grid lg:grid-cols-3">
     <Banner
       class="lg:col-span-1 lg:h-full"
-      :CarlImgPath="'/assets/images/impact/globe 1.svg'"
+      :CarlImgPath="'/assets/images/impact/students%201.svg'"
       :isImageWide="false"
       bgColor="#B1C7D0"
       curveColor="#E5F0F5"
@@ -24,13 +24,13 @@ import Footer from '../../components/Footer/Footer.vue';
       <br />
       <div class="form-description">
         <p>
-          <i><span class="font-semibold">Last updated:</span> July 18, 2025</i>
+          <i><span class="font-semibold">Last updated:</span> July 30, 2025</i>
         </p>
         <br />
         <p>
-          At Audemy, we respect and take your privacy very seriously. We created
-          this policy to explain—clearly and simply—how we handle your
-          information.
+          At <span class="text-primary-color font-bold">Audemy</span>, we
+          respect and take your privacy very seriously. We created this policy
+          to explain—clearly and simply—how we handle your information.
         </p>
         <h2 class="page-subheader">We Don’t Collect Personal Data</h2>
         <p>

--- a/src/pages/Footer/TermsOfUse.vue
+++ b/src/pages/Footer/TermsOfUse.vue
@@ -1,0 +1,133 @@
+<script setup>
+import Banner from '../../components/AccountPages/Banner.vue';
+import Header from '../../components/Header/Header.vue';
+import Footer from '../../components/Footer/Footer.vue';
+
+// Extracted Tailwind classes for readability and DRYer code
+const contactListClasses = [
+  'flex',
+  'flex-col',
+  'gap-y-3',
+  'justify-center',
+  'sm:pl-4',
+  'sm:border-l-2',
+  'sm:border-primary-color',
+  'sm:mx-[15%]',
+  'md:mx-[20%]',
+  'ease-in',
+  'duration-200',
+];
+
+const contactLabelClasses = ['font-semibold', 'mr-[3%]', 'justify-self-start'];
+
+const contactLinkClasses = ['page-link', 'justify-self-end'];
+</script>
+
+<template>
+  <div class="page-container">
+    <Header :logoPath="'/assets/images/header/header-logo-2.png'" />
+  </div>
+  <div class="content-container lg:grid lg:grid-cols-3">
+    <Banner
+      class="lg:col-span-1 lg:h-full"
+      :CarlImgPath="'/assets/images/SignUpImg/signup-carl.png'"
+      bgColor="#B1C7D0"
+      curveColor="#E5F0F5"
+    />
+    <div
+      class="form-container-view-height lg:col-span-2 lg:pb-[50px] text-left"
+    >
+      <h1 class="form-title ml-[10%]">Terms of Use</h1>
+      <br />
+      <div class="form-description">
+        <p>
+          <i><span class="font-semibold">Last updated:</span> July 30, 2025</i>
+        </p>
+        <br />
+        <p>
+          Welcome to <span class="text-primary-color font-bold">Audemy</span>!
+        </p>
+        <br />
+        <p>
+          These Terms & Conditions (“Terms”) govern your use of Audemy’s
+          educational games, services, and website (collectively, the
+          “Services”). By using our Services, you agree to these Terms.
+        </p>
+        <ol>
+          <li>
+            <h2 class="page-subheader">1. Eligibility</h2>
+            <p>
+              Our Services are designed for students, parents, and educators.
+            </p>
+          </li>
+          <li>
+            <h2 class="page-subheader">2. Data and Privacy</h2>
+            <p>
+              Audemy does not collect, store, or share any personal data from
+              users. Our Services are designed to be used without requiring
+              accounts, personal information, or data tracking. Because no user
+              data is collected or stored, there is no risk of your personal
+              information being sold or disclosed.
+            </p>
+          </li>
+          <li>
+            <h2 class="page-subheader">3. Purpose of Services</h2>
+            <p>
+              Audemy provides AI‑powered, educational games designed to support
+              blind and visually impaired students, as well as the broader
+              learning community. The Services are for educational and personal
+              use only and may not be used for commercial resale or distribution
+              without written permission.
+            </p>
+          </li>
+          <li>
+            <h2 class="page-subheader">4. Intellectual Property</h2>
+            <p>
+              All content, games, software, and materials provided through
+              Audemy are the property of Audemy or its licensors. You may not
+              reproduce, sell, or exploit any part of the Services without prior
+              written consent.
+            </p>
+          </li>
+          <li>
+            <h2 class="page-subheader">5. Limitation of Liability</h2>
+            <p>
+              Our Services are provided “as-is,” without warranties of any kind.
+              Since no personal data is collected or stored, Audemy is not
+              responsible for any data loss or unauthorized access to personal
+              information.
+            </p>
+          </li>
+          <li>
+            <h2 class="page-subheader">6. Contact Us</h2>
+            <p>
+              If you have any questions about these Terms, please contact us:
+            </p>
+            <br />
+            <!-- Responsive Container for Email + Website
+                - Parent (list): flex column; inner (each list item): 2-column grid
+            -->
+            <ul :class="contactListClasses">
+              <li class="grid grid-cols-2">
+                <span :class="contactLabelClasses">Email:</span>
+                <a href="mailto:connect@audemy.org" :class="contactLinkClasses"
+                  >connect@audemy.org</a
+                >
+              </li>
+              <li class="grid grid-cols-2">
+                <span :class="contactLabelClasses">Website:</span>
+                <a
+                  href="https://audemy.org/"
+                  target="_blank"
+                  :class="contactLinkClasses"
+                  >www.audemy.org</a
+                >
+              </li>
+            </ul>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+  <Footer />
+</template>

--- a/src/pages/OurProjects/ProjectsInAction/Carousel.vue
+++ b/src/pages/OurProjects/ProjectsInAction/Carousel.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { onMounted, defineProps } from 'vue';
+import { onMounted } from 'vue';
 
 const props = defineProps({
   images: {
     type: Array,
-    required: true
-  }
+    required: true,
+  },
 });
 
 function goToSlide(slide, container) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,7 @@ import LogIn from '../pages/LogIn/LogIn.vue';
 import NotFound from '../pages/NotFound/NotFound.vue';
 import AccessibilityStatement from '../pages/Footer/AccessibilityStatement.vue';
 import PrivacyPolicy from '../pages/Footer/PrivacyPolicy.vue';
+import TermsOfUse from '../pages/Footer/TermsOfUse.vue';
 import SignUp from '../pages/SignUp/SignUp.vue';
 import ForgotPassword from '../pages/ForgotPassword/ForgotPassword.vue';
 import ResetLinkSent from '../pages/ForgotPassword/ResetLinkSent.vue';
@@ -41,6 +42,11 @@ const routes = [
     path: '/privacy-policy',
     name: 'Privacy-Policy',
     component: PrivacyPolicy,
+  },
+  {
+    path: '/terms-of-use',
+    name: 'Terms Of Use',
+    component: TermsOfUse,
   },
   { path: '/login', name: 'LogIn', component: LogIn },
   { path: '/signup', name: 'Sign Up', component: SignUp },


### PR DESCRIPTION
## Summary 

### Key Changes
- Added new responsive **"Terms of Use"** page
  - Linked page in `Footer`
  - Added new route in `index.js`
  - Disallowed page in `robots.txt`
- Minor UI enhancements (**"Privacy Policy"**):
  - Replaced repeated Carl image
    - To reduce visual redundancy and signal a new page when navigating b/t `Footer` pages
  - Added text bolding and color to align with the rest of the `Footer` pages

---

### Minor code cleanup / fixes
- **`<Banner />` component:**
  - Removed `defineProps` comment
  - Removed empty `<style scoped>` block (to align with consistent Tailwind classes)
- **Fixed Vue compiler error:**
  - Removed unnecessary `defineProps` import
  - Affected file: `src/pages/OurProjects/ProjectsInAction/Carousel.vue`
    - (Note: Re-applying Prettier also added two trailing commas for formatting; see lines 7-8)
    
---

## Previews: Terms of Use & Updated Footer

<details>
  <summary><i>View screenshots</i></summary>

| Terms of Use & Updated Footer |
| :--: |
| <img width="1552" height="986" alt="part1" src="https://github.com/user-attachments/assets/1d40db6f-2cd9-48cf-a59f-e3e73d3dde63" /> |
| <img width="1552" height="986" alt="part2" src="https://github.com/user-attachments/assets/6d2ffec1-d09c-4bf8-a65d-79e0af57dc44" /> |
| <img width="1552" height="986" alt="part3" src="https://github.com/user-attachments/assets/77e33636-9467-4253-8651-419119161579" /> |

</details>