### PR TITLE
fix: Responsive `<Header />` (logo & links overlap)

### DIFF
--- a/src/components/Header/Header.vue
+++ b/src/components/Header/Header.vue
@@ -3,10 +3,10 @@
   <!-- 
   Responsive grid layout: 
     - Mobile, small, & medium screens: 
-      - Flex Row: Logo (9/12 cols) + Hamburger icon (3/12 cols)
+      - Single Row: Logo (9/12 cols) + Hamburger icon (3/12 cols)
       - Navbar links overlay: flex column
     - Large+ screens: 
-      - Logo (3/12 cols) + Navbar links (9/12 cols)
+      - Logo (lg: 3/12 | xl: 2/12 cols) + Navbar links (lg: 9/12 | xl: 10/12 cols)
       - Each navbar link / button: flex column
   -->
   <header
@@ -16,7 +16,7 @@
     <!-- Logo Section -->
     <div
       id="logo-item"
-      class="col-span-9 lg:col-span-3 text-lg font-bold pl-2 z-10"
+      class="col-span-9 lg:col-span-3 xl:col-span-2 text-lg font-bold pl-2 z-10"
     >
       <router-link to="/home" aria-hidden="true" tabindex="-1">
         <img
@@ -49,7 +49,7 @@
     <nav
       id="nav-links-grid"
       v-if="!isMobileView & !isTabletView"
-      class="col-start-4 col-span-9 py-2"
+      class="lg:col-start-4 lg:col-span-9 xl:col-start-3 xl:col-span-10 py-2"
     >
       <ul id="router-links-grid" :class="[...navLinksGridClasses]">
         <li id="home-item">
@@ -393,7 +393,7 @@ import { useRouter } from 'vue-router';
 // Extracted Tailwind classes for <router-link> grid layout (desktop)
 const navLinksGridClasses = [
   'flex',
-  'justify-around',
+  'justify-between',
   'items-center',
   'font-poppins',
   'font-semibold',

--- a/src/header-style.css
+++ b/src/header-style.css
@@ -12,7 +12,14 @@
   }
 
   #router-links-grid > li {
-    @apply self-center flex flex-col text-center; /* Align links vertically with logo */
+    /* Large screens: Allow navbar links to fill up space */
+    /* X-Large: Remove flex grow */
+    @apply self-center flex lg:flex-1 xl:flex-initial flex-col text-center duration-300; /* Align links vertically with logo */
+  }
+
+  #router-links-grid > li:not(:first-child) {
+    /* Large screens: Add margin for better spacing; skip first link ('Home') */
+    @apply lg:ml-5 xl:ml-0;
   }
 
   /* --- Mobile Nav Icons --- */


### PR DESCRIPTION
## Summary
### Main Changes
- Fix logo and links overlap during resizing
  - "Home" link was blocked by logo & became unusable on certain screen widths
- Improve readability:
  - Previously, underlined links (hover effects) strikethroughed text when resizing
- Adjust logic to render...
  - a. Navbar menu icon (<kbd>☰</kbd>) for `mobile`, `sm`, and `md` screens
    - **Medium screens now included**
    - **Otherwise:** Need to further reduce text size & push links together → hurts readability
  - b. Text-based links and <kbd>"Game Zone"</kbd> button on `lg`+ screens
- Adjust `lg` RWD layout to align items & fill up space better
- Add new `xl` RWD layout for better spacing and scaling

### Minor Updates
- Adjust & apply shared rules in `header-style.css` stylesheet
- Add inline docs for `<Header/>` RWD & renamed buttons for clarity
- Replace border → w/ underline (to prevent layout shifts)

---

## Before: RWD Issues

<details>
<summary>View Before</summary>

### Logo/Link Overlap, Misalignment, & "Strikethroughed" Text
| Medium | Large | 
| :---:|:---:|
| <img src="https://github.com/user-attachments/assets/af050af2-a6f2-4bab-ae96-f6416ebf6909" width="500" /> | <img src="https://github.com/user-attachments/assets/76210f49-8654-419c-bb3b-6de7011cab68" width="600" /> |

</details>

---

## After 

<details>
<summary>View After</summary>

### Non-Desktop View: Menu Icon (<kbd>☰</kbd>)

| Mobile (ex: `375px`) | Small | Medium | 
|:---:| :---:| :---:| 
| <img  src="https://github.com/user-attachments/assets/ce574b21-de05-41df-a85c-e3d7c5305a3c" width="200" /> | <img  src="https://github.com/user-attachments/assets/eee1b1ef-8c90-4ea7-9dbc-4d85f151e551" width="300" /> | <img src="https://github.com/user-attachments/assets/971722a7-97d8-4c08-ab7c-55827cfc1f54" width="500" /> |

### Large+ View: Text Links & Button

| Large | X-Large (ex: `1680px`) | 
|:---:| :---:| 
| <img src="https://github.com/user-attachments/assets/39d34490-9959-4384-9cdb-0013d11a900d" width="500" /> | <img src="https://github.com/user-attachments/assets/0fbf9125-590b-45d1-a29e-6722b36437ec" width="600" /> |

</details>

---

## Manual Tests
- RWD layout: (`1680px` down to `375px`)
- Hover effects do not hurt readability
- Correct page navigation on both non-desktop and desktop navbars