### PR TITLE
fix: RWD & Keyboard Access. for "Home" & "Our Projects" Carousels

### DIFF
--- a/src/pages/AccessibilityStudio/GamesToLife/GamesShowcase.vue
+++ b/src/pages/AccessibilityStudio/GamesToLife/GamesShowcase.vue
@@ -39,7 +39,8 @@
           v-for="(game, index) in visibleGames"
           :key="index"
           :class="[
-            'game-resource-icon-card bg-cross-lines text-center duration-300',
+            'game-resource-icon-card bg-cross-lines text-center',
+            'hover:shadow-[6px_6px_0px_#0C0D0D] transition-all duration-300',
             'mobile:px-4 mobile:py-6 px-6 py-8',
             'mobile:w-[280px] w-[80%] md:w-[50%] lg:w-[400px]',
             'h-[500px] md:h-[520px] lg:h-[550px]',
@@ -61,7 +62,7 @@
           </div>
 
           <!-- Game Title & Description Container -->
-          <div>
+          <div class="bg-white rounded-lg">
             <!-- Game Title -->
             <h3 class="text-xl font-semibold text-[#2A3338] mb-3">
               {{ game.title }}

--- a/src/pages/Home/Testimonials/Testimonials.vue
+++ b/src/pages/Home/Testimonials/Testimonials.vue
@@ -70,10 +70,25 @@ function prev() {
 // Extracted shared RWD classes for testimonial arrow buttons
 const arrowButtonClasses = [
   'z-10',
+  'w-12' /* Default btn size: Mobile - XL */,
+  'h-12',
+  '2xl:w-16',
+  '2xl:h-16',
   '-translate-y-1/2',
+  'rotate-[-90deg]' /* Mobile - Medium: Up & Down */,
+  'lg:rotate-[0deg]' /* Large+: Left & Right */,
   'absolute',
   'top-1/2',
   'hover:scale-125',
+  'transition',
+  'duration-300',
+];
+
+const arrowIconClasses = [
+  'w-12' /* Default size: Mobile - XL */,
+  'h-12',
+  '2xl:w-16',
+  '2xl:h-16',
   'transition',
   'duration-300',
 ];
@@ -102,84 +117,86 @@ const arrowButtonClasses = [
     </div>
 
     <!-- Carousel Area -->
-    <div class="relative w-full max-w-[92rem] px-4 mobile:px-2">
+    <div class="relative w-full md:w-[90%] px-4 mobile:px-2">
       <!-- Left arrow -->
       <button
         @click="prev"
-        :class="[arrowButtonClasses, 'left-2']"
+        :class="[arrowButtonClasses, 'left-5 md:left-[10%] lg:left-2']"
         aria-label="View previous review"
       >
         <img
           src="/assets/images/testimonials/arrow.png"
           aria-hidden="true"
-          class="w-12 h-12 rotate-180"
+          :class="[arrowIconClasses, 'rotate-180', 'xl:-translate-x-5']"
         />
       </button>
 
       <!-- Testimonial Cards -->
-      <div class="flex gap-6 justify-center overflow-hidden">
+      <!-- Enable vertical (mobile-md) / horizontal (lg+) scrolling on desktop & mobile devices -->
+      <div
+        :class="[
+          'h-[600px] w-full p-5',
+          'flex flex-col lg:flex-row lg:flex-nowrap',
+          'justify-center items-center justify-between md:gap-8 lg:gap-12 xl:justify-between',
+          'overflow-y-auto lg:overflow-x-auto',
+        ]"
+      >
         <div
           v-for="(testimonial, index) in visibleTestimonials"
           :key="index"
           :class="[
-            'game-resource-icon-card bg-cross-lines text-center duration-300',
+            'game-resource-icon-card bg-cross-lines text-center',
+            'hover:shadow-[6px_6px_0px_#0C0D0D] transition-all duration-300',
             'mobile:px-4 mobile:py-6 px-6 py-8',
-            'w-[320px] h-[520px]',
-            'flex flex-col items-center',
+            'mobile:w-[280px] w-[70%] md:w-[60%] lg:w-[400px]',
+            'h-[500px] md:h-[520px] lg:h-[550px]',
+            'flex flex-col justify-start',
           ]"
         >
           <!-- Image -->
           <img
             :src="testimonial.image"
             aria-hidden="true"
-            class="w-full h-[160px] object-cover rounded-md mb-4"
+            class="w-full h-[180px] lg:h-[160px] object-cover rounded-md mb-4 shadow-lg"
           />
 
           <!-- Scrollable Text Content -->
-          <div class="overflow-y-auto no-scrollbar max-h-[220px] mb-4 px-1">
+          <div class="h-[180px] overflow-y-auto mb-4 px-2">
             <p
-              class="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap"
+              class="text-[14px] text-[15px] 2xl:text-[16px] text-gray-700 leading-relaxed whitespace-pre-wrap"
               v-html="testimonial.text"
             ></p>
           </div>
-          <!-- Name -->
-          <p class="text-[15px] font-semibold text-[#2A3338] mt-2">
-            – {{ testimonial.name }}
-          </p>
-          <!-- Role -->
-          <p
-            class="text-[14px] text-[#2A3338] mt-2 font-poppins leading-snug"
-            v-html="testimonial.role"
-          ></p>
+
+          <!-- Testimonial Name & Role Container -->
+          <div class="mt-auto flex flex-col flex-1">
+            <!-- Name -->
+            <p
+              class="mobile:text-[14px] text-[15px] 2xl:text-[16px] font-semibold text-[#2A3338] mt-2 duration-300"
+            >
+              – {{ testimonial.name }}
+            </p>
+            <!-- Role -->
+            <p
+              class="text-[15px] text-[#2A3338] mt-2 leading-snug"
+              v-html="testimonial.role"
+            ></p>
+          </div>
         </div>
       </div>
 
       <!-- Right arrow -->
       <button
         @click="next"
-        :class="[arrowButtonClasses, 'right-2']"
+        :class="[arrowButtonClasses, 'right-5 md:right-[10%] lg:right-2']"
         aria-label="View next review"
       >
         <img
           src="/assets/images/testimonials/arrow.png"
           aria-hidden="true"
-          class="w-12 h-12"
+          :class="[arrowIconClasses, 'xl:translate-x-5']"
         />
       </button>
     </div>
   </div>
 </template>
-
-<style scoped>
-.no-scrollbar::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-.no-scrollbar {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
-.fill {
-  width: -webkit-fill-available;
-}
-</style>

--- a/src/pages/Home/Testimonials/Testimonials.vue
+++ b/src/pages/Home/Testimonials/Testimonials.vue
@@ -4,46 +4,46 @@ import { ref, computed } from 'vue';
 const testimonials = [
   {
     image: '/assets/images/testimonials/testimonial1.png',
-    text: `"I appreciate Audemy.org for offering a wide variety of games, particularly those focused on nourishing life skills and independence. The option to reward my students at the end of their lessons with 5 quick educational questions/games, fits in well into our busy schedule."`,
+    text: `"I appreciate Audemy.org for offering a wide variety of games, particularly those focused on nourishing life skills and independence. <p class="mt-3">The option to reward my students at the end of their lessons with 5 quick educational questions/games, fits in well into our busy schedule."</p>`,
     name: 'Stephanie Bissonette',
-    role: 'Director of Children Services at the Vermont Association for the Blind (sbissonette@vabvi.org)',
+    role: '<i>Director of Children Services at the Vermont Association for the Blind</i> <p class="mt-3"><a href="mailto:sbissonette@vabvi.org" class="underline hover:text-primary-color transition-colors duration-300" tabindex="-1">sbissonette@vabvi.org</a></p>',
   },
   {
     image: '/assets/images/impact/arizonaStudent.png',
-    text: `"Hello! My name is Denise Bean, Youth Service Librarian for the Iowa Library for the Blind and Print Disabled, and one of the greatest joys of my work is building meaningful connections with children who are blind or have low vision. During one of our 28 virtual Summer Reading Program events, we introduced a game called Audemy, and what an unforgettable experience it was! The children lit up with excitement, laughter filled the room, and the joy was contagious."`,
+    text: `"Hello! My name is Denise Bean, Youth Service Librarian for the Iowa Library for the Blind and Print Disabled, and one of the greatest joys of my work is building meaningful connections with children who are blind or have low vision. <p class="mt-3">During one of our 28 virtual Summer Reading Program events, we introduced a game called Audemy, and what an unforgettable experience it was! The children lit up with excitement, laughter filled the room, and the joy was contagious."</p>`,
     name: 'Denise Bean',
-    role: 'Youth service librarian from the Iowa Library for the Blind (Denise.Bean@blind.state.ia.us)',
+    role: '<i>Youth Service Librarian from the Iowa Library for the Blind</i> <p class="mt-3"><a href="mailto:denise.bean@blind.state.ia.us" class="underline hover:text-primary-color transition-colors duration-300" tabindex="-1">denise.bean@blind.state.ia.us</a></p>',
   },
   {
     image: '/assets/images/testimonials/testimonial2.png',
-    text: `"The audio gaming experience on Audemy is incredible! My students are completely immersed in the games - the sound effects, voice acting, and interactive gameplay make it feel like a real gaming console. They can't get enough of the adventure-style games!"`,
+    text: `"The audio gaming experience on Audemy is incredible! <p class="mt-3">My students are completely immersed in the games - the sound effects, voice acting, and interactive gameplay make it feel like a real gaming console. They can't get enough of the adventure-style games!"</p>`,
     name: 'Technology Coordinator',
-    role: 'Texas School for the Blind and Visually Impaired',
+    role: '<i>Texas School for the Blind and Visually Impaired</i>',
   },
   {
     image: '/assets/images/testimonials/testimonial3.png',
-    text: `"Audemy's gaming platform is revolutionary for blind gamers. The audio-only design creates an immersive experience that rivals mainstream games. Our students love competing with each other and achieving high scores!"`,
+    text: `"Audemy's gaming platform is revolutionary for blind gamers. The audio-only design creates an immersive experience that rivals mainstream games. <p class="mt-3">Our students love competing with each other and achieving high scores!"</p>`,
     name: 'Workshop Coordinator',
-    role: 'Massachusetts Lighthouse for the Blind',
+    role: '<i>Massachusetts Lighthouse for the Blind</i>',
   },
   {
     image: '/assets/images/testimonials/testimonial4.png',
-    text: `"Audemy's games are so much fun! I love the car racing game and the adventure quests. The sound effects make me feel like I'm really driving or exploring. It's the coolest gaming experience I've ever had!"`,
+    text: `"Audemy's games are so much fun! I love the car racing game and the adventure quests. <p class="mt-3">The sound effects make me feel like I'm really driving or exploring. It's the coolest gaming experience I've ever had!"</p>`,
     name: 'Adam',
-    role: 'A Student who is blind from Houston',
+    role: '<i>A Student who is blind from Houston</i>',
   },
 
   {
     image: '/assets/images/impact/5b46078e-65e0-42c8-a658-2939c6676a21.jpeg',
-    text: `"The gaming mechanics on Audemy are brilliant! The audio cues, spatial awareness features, and competitive elements create an engaging gaming experience that keeps our players coming back. It's like having a professional gaming studio designed specifically for blind gamers."`,
+    text: `"The gaming mechanics on Audemy are brilliant! The audio cues, spatial awareness features, and competitive elements create an engaging gaming experience that keeps our players coming back. <p class="mt-3">It's like having a professional gaming studio designed specifically for blind gamers."</p>`,
     name: 'Technology Specialist',
-    role: 'Iowa Center for the Blind',
+    role: '<i>Iowa Center for the Blind</i>',
   },
   {
     image: '/assets/images/impact/carousel/carousel1.jpg',
-    text: `"Audemy has transformed our gaming programs! The multiplayer features and leaderboards create a social gaming experience that's rare for blind players. Crystal has created something truly special - a gaming platform that's both accessible and genuinely fun to play."`,
+    text: `"Audemy has transformed our gaming programs! The multiplayer features and leaderboards create a social gaming experience that's rare for blind players. <p class="mt-3">Crystal has created something truly special - a gaming platform that's both accessible and genuinely fun to play."</p>`,
     name: 'Librarian',
-    role: 'for Blind Students',
+    role: '<i>for Blind Students</i>',
   },
 ];
 
@@ -66,25 +66,38 @@ function prev() {
   currentIndex.value =
     (currentIndex.value - 1 + testimonials.length) % testimonials.length;
 }
+
+// Extracted shared RWD classes for testimonial arrow buttons
+const arrowButtonClasses = [
+  'z-10',
+  '-translate-y-1/2',
+  'absolute',
+  'top-1/2',
+  'hover:scale-125',
+  'transition',
+  'duration-300',
+];
 </script>
 
 <template>
   <div
-    class="my-10 py-80 flex flex-col items-center gap-y-12 self-center pt-80 relative z-10"
+    :class="[
+      'z-10 font-poppins my-10 py-80',
+      'relative flex flex-col gap-y-12 items-center self-center',
+    ]"
   >
     <!-- Background image -->
     <img
       src="/assets/images/testimonials/testimonials-bg.png"
-      class="absolute top-[4rem] -z-10 h-[70rem] fill"
-      alt="Background image"
+      class="absolute top-[4rem] -z-10 h-[70rem] w-full"
+      aria-hidden="true"
     />
 
     <!-- Section Title -->
-    <div
-      class="font-poppins flex flex-col gap-y-3 mobile:px-5 text-center relative"
-    >
-      <h1 class="text-4.5xl text-title mobile:text-[24px]">
-        What people are saying:
+    <div class="flex flex-col gap-y-3 mobile:px-5 text-center relative">
+      <h1 class="page-header">
+        What <span class="font-semibold text-primary-color">people</span> are
+        saying:
       </h1>
     </div>
 
@@ -93,11 +106,12 @@ function prev() {
       <!-- Left arrow -->
       <button
         @click="prev"
-        class="absolute left-2 top-1/2 -translate-y-1/2 z-10 hover:scale-125 transition"
+        :class="[arrowButtonClasses, 'left-2']"
+        aria-label="View previous review"
       >
         <img
           src="/assets/images/testimonials/arrow.png"
-          alt="Previous"
+          aria-hidden="true"
           class="w-12 h-12 rotate-180"
         />
       </button>
@@ -107,44 +121,48 @@ function prev() {
         <div
           v-for="(testimonial, index) in visibleTestimonials"
           :key="index"
-          class="bg-white border-2 border-[#2A3338] shadow-[3px_4px_0px_#0C0D0D] rounded-lg flex flex-col items-center text-center px-6 py-8 mobile:px-4 mobile:py-6 w-[320px] h-[520px]"
+          :class="[
+            'game-resource-icon-card bg-cross-lines text-center duration-300',
+            'mobile:px-4 mobile:py-6 px-6 py-8',
+            'w-[320px] h-[520px]',
+            'flex flex-col items-center',
+          ]"
         >
           <!-- Image -->
           <img
             :src="testimonial.image"
-            alt="testimonial image"
+            aria-hidden="true"
             class="w-full h-[160px] object-cover rounded-md mb-4"
           />
 
           <!-- Scrollable Text Content -->
           <div class="overflow-y-auto no-scrollbar max-h-[220px] mb-4 px-1">
             <p
-              class="text-sm text-gray-700 font-poppins leading-relaxed whitespace-pre-wrap"
-            >
-              {{ testimonial.text }}
-            </p>
+              class="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap"
+              v-html="testimonial.text"
+            ></p>
           </div>
-
           <!-- Name -->
-          <p class="text-[15px] font-semibold font-poppins text-[#2A3338] mt-2">
+          <p class="text-[15px] font-semibold text-[#2A3338] mt-2">
             – {{ testimonial.name }}
           </p>
-
           <!-- Role -->
-          <p class="text-sm text-[#2A3338] mt-2 font-poppins leading-snug">
-            {{ testimonial.role }}
-          </p>
+          <p
+            class="text-[14px] text-[#2A3338] mt-2 font-poppins leading-snug"
+            v-html="testimonial.role"
+          ></p>
         </div>
       </div>
 
       <!-- Right arrow -->
       <button
         @click="next"
-        class="absolute right-2 top-1/2 -translate-y-1/2 z-10 hover:scale-125 transition"
+        :class="[arrowButtonClasses, 'right-2']"
+        aria-label="View next review"
       >
         <img
           src="/assets/images/testimonials/arrow.png"
-          alt="Next"
+          aria-hidden="true"
           class="w-12 h-12"
         />
       </button>

--- a/src/pages/Home/Testimonials/Testimonials.vue
+++ b/src/pages/Home/Testimonials/Testimonials.vue
@@ -161,7 +161,7 @@ const arrowIconClasses = [
           />
 
           <!-- Scrollable Text Content -->
-          <div class="h-[180px] overflow-y-auto mb-4 px-2">
+          <div class="bg-white rounded-lg h-[180px] overflow-y-auto mb-4 px-2">
             <p
               class="text-[14px] text-[15px] 2xl:text-[16px] text-gray-700 leading-relaxed whitespace-pre-wrap"
               v-html="testimonial.text"
@@ -169,7 +169,7 @@ const arrowIconClasses = [
           </div>
 
           <!-- Testimonial Name & Role Container -->
-          <div class="mt-auto flex flex-col flex-1">
+          <div class="bg-white rounded-lg mt-auto flex flex-col flex-1 justify-center">
             <!-- Name -->
             <p
               class="mobile:text-[14px] text-[15px] 2xl:text-[16px] font-semibold text-[#2A3338] mt-2 duration-300"

--- a/src/pages/Impact/PressList/PressListCard.vue
+++ b/src/pages/Impact/PressList/PressListCard.vue
@@ -32,11 +32,12 @@ const path = '/assets/images/impact/';
             target="_blank"
             rel="noopener noreferrer"
             class="block w-full"
+            tabindex="-1"
           >
             <img
               :src="path + image"
               class="w-full h-[150px] object-cover rounded-2xl border-[1px] border-[#E5E5E5] hover:opacity-80 transition-opacity duration-200 cursor-pointer"
-              alt=""
+              aria-hidden="true"
             />
           </a>
         </div>

--- a/src/pages/OurProjects/OurProjects.vue
+++ b/src/pages/OurProjects/OurProjects.vue
@@ -14,13 +14,14 @@ import Footer from '../../components/Footer/Footer.vue';
 <template>
   <ScrollUpButton />
 
-  <div class="relative px-8 sm:px-8 md:px-6 lg:px-14">
+  <div class="relative px-8 sm:px-8 md:px-6 lg:px-14 font-poppins">
     <Header :logoPath="'/assets/images/header/header-logo-2.png'" />
   </div>
 
-  <div class="flex flex-col">
-    <div class="flex justify-center px-8 md:px-14 xl:mt-20">
-      <div class="md:w-full md:mt-10">
+  <div class="flex flex-col font-poppins">
+    <!-- Accessibility: Hide decorative image carousel from SR output -->
+    <div class="flex justify-center px-8 md:px-14" aria-hidden="true">
+      <div class="md:w-full">
         <ProjectsInAction />
       </div>
     </div>
@@ -31,20 +32,20 @@ import Footer from '../../components/Footer/Footer.vue';
       </div>
     </div>
 
-    <div class="flex justify-center px-8 md:px-14 mt-36">
+    <div class="flex justify-center px-10 py-10 my-36">
       <div class="md:w-full">
         <HaveYouHeard />
       </div>
     </div>
 
-    <div class="flex justify-center px-8 md:px-14 mt-36">
+    <div class="flex justify-center mx-10 my-10">
       <div class="md:w-full">
         <KatyYouthHacks />
       </div>
     </div>
 
-    <div class="flex justify-center px-8 md:px-14 my-36">
-      <div class="md:w-full">
+    <div class="flex justify-center px-10 py-10 my-36">
+      <div class="md:w-[80%]">
         <SocialMedia />
       </div>
     </div>

--- a/src/pages/OurProjects/OurProjects.vue
+++ b/src/pages/OurProjects/OurProjects.vue
@@ -20,7 +20,7 @@ import Footer from '../../components/Footer/Footer.vue';
 
   <div class="flex flex-col font-poppins">
     <!-- Accessibility: Hide decorative image carousel from SR output -->
-    <div class="flex justify-center px-8 md:px-14" aria-hidden="true">
+    <div class="flex justify-center px-8 md:px-14">
       <div class="md:w-full">
         <ProjectsInAction />
       </div>

--- a/src/pages/OurProjects/ProjectsInAction/Carousel.vue
+++ b/src/pages/OurProjects/ProjectsInAction/Carousel.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted } from 'vue';
+import { onMounted, ref } from 'vue';
 
 const props = defineProps({
   images: {
@@ -8,80 +8,109 @@ const props = defineProps({
   },
 });
 
+const currentSlide = ref(0);
+const carousel = ref(null);
+const maxLength = ref(0);
+
 function goToSlide(slide, container) {
-  container.forEach((s, i) => {
-    s.style.transform = `translateX(${100 * (i - slide)}%)`;
+  container.value.forEach((s, i) => {
+    s.style.transform = `translateX(${100 * (i - slide.value)}%)`;
   });
 }
 
+const goToPrevSlide = () => {
+  if (currentSlide.value === 0) return;
+  currentSlide.value--;
+  goToSlide(currentSlide, carousel);
+};
+
+const goToNextSlide = () => {
+  if (currentSlide.value === maxLength.value - 1) {
+    currentSlide.value = 0;
+  } else {
+    currentSlide.value++;
+  }
+  goToSlide(currentSlide, carousel);
+};
+
 onMounted(() => {
-  const carousel = document.querySelectorAll('.carousel__slide');
+  // Define carousel object & max length
+  carousel.value = document.querySelectorAll('.carousel__slide');
+  maxLength.value = carousel.value.length;
+
+  // Reset carousel to first slide
   goToSlide(0, carousel);
-  const prevButton = document.getElementById('left-chevron');
-  const nextButton = document.getElementById('right-chevron');
-
-  let currentSlide = 0;
-  const maxLength = carousel.length;
-
-  prevButton.addEventListener('click', () => {
-    if (currentSlide === 0) return;
-    currentSlide--;
-    goToSlide(currentSlide, carousel);
-  });
-
-  nextButton.addEventListener('click', () => {
-    if (currentSlide === maxLength - 1) {
-      currentSlide = 0;
-    } else {
-      currentSlide++;
-    }
-    goToSlide(currentSlide, carousel);
-  });
+  currentSlide.value = 0;
 });
 
-// Extracted shared classes for arrow buttons
+// Extracted shared RWD classes for arrow buttons
 const arrowButtonClasses = [
   'absolute',
   'top-1/2',
-  '-translate-1/2',
   'z-10',
+  'w-10',
+  'h-10',
+  '2xl:w-14',
+  '2xl:h-14',
+];
+
+// Extracted shared RWD classes for arrow icons
+const arrowIconClasses = [
   'cursor-pointer',
-  'w-8',
-  'h-8',
-  'hover:w-10',
-  'hover:h-10',
+  'w-10',
+  'h-10',
+  '2xl:w-14',
+  '2xl:h-14',
+  'transition',
+  'hover:scale-125',
   'duration-300',
 ];
 </script>
 
 <template>
-  <div class="relative carousel mobile:h-60 h-80 xl:h-96 overflow-hidden">
+  <div class="relative h-full w-full">
     <!-- Previous / Left icon -->
-    <img
-      src="/assets/images/impact/carousel/leftChevron.svg"
-      id="left-chevron"
-      :class="[arrowButtonClasses, 'left-1']"
-      aria-hidden="true"
-    />
-
-    <!-- Render slides dynamically from prop -->
-    <div
-      v-for="(img, index) in images"
-      :key="index"
-      class="carousel__slide absolute top-0 left-0 w-full h-full duration-500"
+    <button
+      @click="goToPrevSlide"
+      aria-label="See previous image"
+      :class="[arrowButtonClasses, '-left-12 md:-left-16']"
     >
       <img
-        :src="img"
-        class="-z-10 w-full h-full object-cover rounded-[16px] shadow-lg"
+        src="/assets/images/testimonials/arrow.png"
+        :class="[arrowIconClasses, 'rotate-180']"
         aria-hidden="true"
       />
+    </button>
+    <div
+      class="relative carousel mobile:h-60 h-80 xl:h-96 overflow-hidden"
+      id="projects-carousel"
+    >
+      <!-- Render slides dynamically from prop -->
+      <!-- SR Accessibility: Conditionally set aria-hidden & output alt text -->
+      <div
+        v-for="(img, index) in images"
+        :key="index"
+        class="carousel__slide absolute top-0 left-0 w-full h-full duration-500"
+        :aria-hidden="index == !currentSlide"
+      >
+        <img
+          :src="img.src"
+          :alt="img.alt"
+          class="-z-10 w-full h-full object-cover rounded-[16px] shadow-lg"
+        />
+      </div>
     </div>
     <!-- Next / Right icon -->
-    <img
-      src="/assets/images/impact/carousel/rightChevron.svg"
-      id="right-chevron"
-      :class="[arrowButtonClasses, 'right-1']"
-      aria-hidden="true"
-    />
+    <button
+      @click="goToNextSlide"
+      aria-label="See next image"
+      :class="[arrowButtonClasses, '-right-12 md:-right-16']"
+    >
+      <img
+        src="/assets/images/testimonials/arrow.png"
+        :class="[arrowIconClasses]"
+        aria-hidden="true"
+      />
+    </button>
   </div>
 </template>

--- a/src/pages/OurProjects/ProjectsInAction/Carousel.vue
+++ b/src/pages/OurProjects/ProjectsInAction/Carousel.vue
@@ -19,13 +19,18 @@ function goToSlide(slide, container) {
 }
 
 const goToPrevSlide = () => {
-  if (currentSlide.value === 0) return;
-  currentSlide.value--;
+  if (currentSlide.value === 0) {
+    // Circular behavior: Go to last image
+    currentSlide.value = maxLength.value - 1;
+  } else {
+    currentSlide.value--;
+  }
   goToSlide(currentSlide, carousel);
 };
 
 const goToNextSlide = () => {
   if (currentSlide.value === maxLength.value - 1) {
+    // Circular behavior: Go to first image
     currentSlide.value = 0;
   } else {
     currentSlide.value++;
@@ -39,8 +44,8 @@ onMounted(() => {
   maxLength.value = carousel.value.length;
 
   // Reset carousel to first slide
-  goToSlide(0, carousel);
   currentSlide.value = 0;
+  goToSlide(currentSlide, carousel);
 });
 
 // Extracted shared RWD classes for arrow buttons

--- a/src/pages/OurProjects/ProjectsInAction/Carousel.vue
+++ b/src/pages/OurProjects/ProjectsInAction/Carousel.vue
@@ -38,15 +38,30 @@ onMounted(() => {
     goToSlide(currentSlide, carousel);
   });
 });
+
+// Extracted shared classes for arrow buttons
+const arrowButtonClasses = [
+  'absolute',
+  'top-1/2',
+  '-translate-1/2',
+  'z-10',
+  'cursor-pointer',
+  'w-8',
+  'h-8',
+  'hover:w-10',
+  'hover:h-10',
+  'duration-300',
+];
 </script>
 
 <template>
-  <div class="relative carousel h-48 md:h-60 xl:h-96 overflow-hidden">
+  <div class="relative carousel mobile:h-60 h-80 xl:h-96 overflow-hidden">
+    <!-- Previous / Left icon -->
     <img
       src="/assets/images/impact/carousel/leftChevron.svg"
       id="left-chevron"
-      class="absolute top-1/2 left-1 -translate-1/2 z-10 cursor-pointer"
-      alt="Left Chevron"
+      :class="[arrowButtonClasses, 'left-1']"
+      aria-hidden="true"
     />
 
     <!-- Render slides dynamically from prop -->
@@ -57,16 +72,16 @@ onMounted(() => {
     >
       <img
         :src="img"
-        class="-z-10 w-full h-full object-cover"
-        alt="Carousel Image"
+        class="-z-10 w-full h-full object-cover rounded-[16px] shadow-lg"
+        aria-hidden="true"
       />
     </div>
-
+    <!-- Next / Right icon -->
     <img
       src="/assets/images/impact/carousel/rightChevron.svg"
       id="right-chevron"
-      class="absolute top-1/2 right-1 -translate-1/2 z-10 cursor-pointer"
-      alt="Right Chevron"
+      :class="[arrowButtonClasses, 'right-1']"
+      aria-hidden="true"
     />
   </div>
 </template>

--- a/src/pages/OurProjects/ProjectsInAction/ProjectsInAction.vue
+++ b/src/pages/OurProjects/ProjectsInAction/ProjectsInAction.vue
@@ -1,5 +1,10 @@
 <script setup>
 import Carousel from './Carousel.vue';
+import PageDecorations from '../../../components/PageDecorations/PageDecorations.vue';
+import Bubble from '/assets/images/impact/Group 1153.png';
+import OrangeStar from '/assets/images/impact/Group 1135.png';
+import YellowStar from '/assets/images/testimonials/star.svg';
+import BlueStar from '/assets/images/about-us/blueStar2.svg';
 
 const impactImages = [
   '/assets/images/impact/carousel/carousel1.jpg',
@@ -11,47 +16,50 @@ const impactImages = [
 </script>
 
 <template>
-  <div class="flex flex-col gap-4 relative md:flex-row lg:gap-10 pb-20">
+  <div
+    class="flex flex-col gap-4 relative lg:flex-row lg:gap-10 md:p-20 xl:p-24"
+  >
+    <!-- Background & page decorations -->
     <img
       src="/assets/images/impact/Union.png"
-      class="absolute max-w[100px] -z-10 -top-6 -left-8 md:-left-14 md:-top-14 xl:-top-28"
-      alt="Union Image"
+      class="absolute -z-10 -top-6 -left-8 md:-left-14 md:-top-14 xl:-top-28"
+      aria-hidden="true"
     />
-    <img
-      src="/assets/images/impact/Group 1135.png"
-      class="absolute right-28 top-8 h-8 md:h-16 md:left-56 xl:left-72 z-20"
-      alt="Star Icon"
+    <PageDecorations
+      class="hidden md:block"
+      :topRightImgPath="Bubble"
+      :topLeftImgPath="BlueStar"
+      :bottomLeftImgPath="OrangeStar"
+      :bottomRightImgPath="YellowStar"
+      increaseIconSize="true"
     />
-    <img
-      src="/assets/images/impact/Group 1153.png"
-      class="absolute left-20 -top-5 h-8 md:h-16 md:left-24 md:-top-10 xl:-top-14 z-20"
-      alt="Chat Icon"
-    />
-
-    <div class="p-4 md:basis-1/2">
-      <div class="bg-white rounded-xl border-4 border-[#2A3338] p-2">
-        <div
-          class="h-full rounded-xl border-4 border-[#2A3338] overflow-hidden xl:h-96"
-        >
-          <Carousel :images="impactImages" />
-        </div>
+    <div
+      class="flex items-center flex-col w-full lg:flex-row lg:w-1/2 justify-center"
+    >
+      <div
+        class="rounded-[16px] bg-cross-lines shadow-md w-full my-10 md:my-0 mobile:py-12 p-12 md:py-16"
+      >
+        <Carousel :images="impactImages" />
       </div>
     </div>
-    <div class="flex items-center font-poppins text-center md:basis-1/2">
-      <div class="flex flex-col gap-6 text-start">
-        <h2 class="text-[32px] md:text-4.5xl">
+    <div
+      class="flex items-center flex-col w-full lg:flex-row lg:w-1/2 justify-center"
+    >
+      <div class="flex flex-col gap-6 text-center">
+        <h2 class="page-header">
           Discover how we make
-          <span style="color: #077bb3" class="font-semibold">
+          <span class="font-semibold text-primary-color">
             education accessible
           </span>
         </h2>
 
-        <p class="text-lg text-body leading-8 lg:text-xl">
-          <strong>
-            Our innovative technologies and educational initiatives
-          </strong>
+        <p class="page-text">
+          Our <span class="font-semibold">innovative technologies</span> and
+          <span class="font-semibold">educational initiatives </span>
           provide fun learning for
-          <strong> blind and visually impaired individuals</strong>.
+          <span class="font-semibold">
+            blind and visually impaired individuals.</span
+          >
         </p>
       </div>
     </div>

--- a/src/pages/OurProjects/ProjectsInAction/ProjectsInAction.vue
+++ b/src/pages/OurProjects/ProjectsInAction/ProjectsInAction.vue
@@ -6,12 +6,28 @@ import OrangeStar from '/assets/images/impact/Group 1135.png';
 import YellowStar from '/assets/images/testimonials/star.svg';
 import BlueStar from '/assets/images/about-us/blueStar2.svg';
 
+// impactImages: Maps image src and alt text to dynamically render <Carousel/>
 const impactImages = [
-  '/assets/images/impact/carousel/carousel1.jpg',
-  '/assets/images/impact/carousel/carousel2.png',
-  '/assets/images/impact/carousel/carousel3.png',
-  '/assets/images/impact/carousel/carousel4.png',
-  '/assets/images/impact/carousel/carousel5.png',
+  {
+    src: '/assets/images/impact/carousel/carousel1.jpg',
+    alt: 'Student playing spelling games on Audemy',
+  },
+  {
+    src: '/assets/images/impact/carousel/carousel2.png',
+    alt: 'Student playing Fruit Frenzy on laptop',
+  },
+  {
+    src: '/assets/images/impact/carousel/carousel3.png',
+    alt: 'Student playing Spell Safari',
+  },
+  {
+    src: '/assets/images/impact/carousel/carousel4.png',
+    alt: 'Student playing Fruit Frenzy',
+  },
+  {
+    src: '/assets/images/impact/carousel/carousel5.png',
+    alt: 'Another student playing Fruit Frenzy',
+  },
 ];
 </script>
 


### PR DESCRIPTION
# Reference
- [Issue #85](https://github.com/Crustaly/audemywebsite/issues/85): Keyboard access. for `<Carousel/>`

--- 

# Summary
## Key Changes
- Fix RWD for `<Testimonials/>` carousel on "Home" page
  - **Before:**
    - Narrow text/cards & unequal images during resizing
- Fix RWD for `<Carousel/>` on "Our Projects" page
- Fix keyboard accessibility for "Our Projects" `<Carousel/>`
  - **Before:**
    - Buttons = not tabbable; did not respond to <kbd>Enter</kbd>
  - **Approach:**
    - Replace static values with reactive constants
    - Add semantic, functional `<button @click="...">` 
    - Add bindings to new `goToPrevSlide()` and `goToNextSlide()` functions
    - Add image mappings (`src` & `alt`) for dynamic `<Carousel/>` SR output

## Supporting updates
<details>
  <summary>View</summary>

- **Circular Behavior Fix: `<Carousel/>`**
  - **Before:** <kbd>Previous</kbd> button did nothing on the first image
  - **After:** Fast-forwards to last image; aligns with <kbd>Next</kbd> button's behavior

- **Fix Screen Reader Access in "Home"**
  - Hide icons and images from SR output
  - Hide redundant `<PressListCard/>` links from the tab order 

- **Minor UI updates, refactor, & DRY classes**
  - Format text and emails for UI readability (via `v-html`)
  - Add scrolling to `<Testimonials/>`

</details>

  
---

# Previews

## Home: `<Testimonials/>` 

<details>
  <summary>View screenshots (RWD)</summary>

### Before & After: Mobile - Medium RWD 

| Before | After | 
|:---: |:---: |
| <img src="https://github.com/user-attachments/assets/eef02604-c9e6-4a7d-b4fa-6e5483a98a25" width="300" /> | <img width="300" alt="mobile small" src="https://github.com/user-attachments/assets/47f5464a-be43-4e3e-ae80-127f8774e28e" /> | 

</details>

<details>
<summary>View live demo (RWD + Enabled Scrolling)</summary>

### Live Demo: RWD + Scrolling
| Mobile - Medium |
|:---: |
| <video src="https://github.com/user-attachments/assets/63e33f9b-8f9b-43a4-bcb4-14aafaa93d02" width="250" controls /> |

</details>

---

## Our Projects: `<Carousel/>`

<details>
  <summary>View demos (RWD & UI Updates)</summary>

### RWD & UI Updates

| Before | After |  
|:---: | :---: |
| <img width="300" alt="Screenshot 2025-08-31 at 5 18 11 PM" src="https://github.com/user-attachments/assets/6fc260b6-fbed-4e54-90b5-376840d6a68b" /> | <img src="https://github.com/user-attachments/assets/4d3d3508-95e7-47e9-930e-0f397633f285" width="300" /> | 

| Medium | Large - 2XL | 
|:---: |:---: | 
| <img src="https://github.com/user-attachments/assets/4744a2a9-c2a1-49b6-8132-991a9c9c0d3a" width="500" /> | <img src="https://github.com/user-attachments/assets/50f72f8a-b371-4a94-bbcc-4bd04cd81fd4" width="500" /> |

</details>


<details>
<summary>View live demo (Keyboard Access)</summary>

### Live Demo
| Mobile - Medium |
|:---: |
| <video src="https://github.com/user-attachments/assets/ee6cbeb2-7e06-4b55-a133-f7add2e3fb9d" width="500" controls /> |

</details>

---

# Manual Tests

<details>
  <summary>View</summary>

- **RWD:** 
  - Test screen widths from `375px` (**mobile**) to `1680px` (**2xl**)
- **Lighthouse Audit:** 
  - No accessibility issues for `<Testimonials/>` & `<Carousel/>`
  - Carousel buttons are accessible via <kbd>Tab</kbd> and <kbd>Enter</kbd>
- **Home:**
  - Redundant `<PressListCard/>` images are skipped in the tab order
  - Focus correctly goes to text-based links 
- **Our Projects:**
  - **Circular Navigation:** <kbd>Previous</kbd> button from first image skips to last
  
</details>
  