### PR TITLE
Changed Affiliated Organizations to Associated Organizations

### DIFF
--- a/src/pages/Impact/CollaboratingSchools/Affiliates.vue
+++ b/src/pages/Impact/CollaboratingSchools/Affiliates.vue
@@ -219,7 +219,7 @@ const teachers = [
         currentPage == 1 ? activeTabClasses : inactiveTabClasses,
       ]"
     >
-      Affiliated Organizations
+      Associated Organizations
     </button>
   </div>
 


### PR DESCRIPTION
This PR address minor UI changes: 
- Changed Affiliated Organizations to Associated Organizations on the Impacts page. 