### PR TITLE
fix: RWD for site-wide buttons

### DIFF
--- a/src/game-resources-style.css
+++ b/src/game-resources-style.css
@@ -23,15 +23,6 @@
     @apply text-white text-2xl font-bold;
   }
 
-  /* --- Responsive buttons --- */
-  .game-resource-btn-flex {
-    @apply flex mobile:flex-col justify-center items-center my-10;
-  }
-
-  .game-resource-base-btn {
-    @apply page-button tracking-wide font-[600] text-center duration-300 text-[16px] w-[300px] h-[70px] md:h-[60px] mobile:h-[80px] py-3 md:py-5;
-  }
-
   /* --- Decorative colored banner & icon cards --- */
   .game-resource-card-banner {
     @apply z-0 bg-[#0a7db8] absolute top-0 left-0 w-full rounded-t-md;

--- a/src/pages/AccessibilityStudio/AccessibilityStudio.vue
+++ b/src/pages/AccessibilityStudio/AccessibilityStudio.vue
@@ -40,10 +40,10 @@ import GamesShowcase from './GamesToLife/GamesShowcase.vue';
           </p>
         </div>
         <!-- Start Test Button -->
-        <div class="game-resource-btn-flex">
+        <div class="page-button-flex">
           <a
             href="mailto:connect@audemy.org"
-            class="game-resource-base-btn orange-button mx-auto h-[70px] tablet:h-[60px] mobile:px-5 py-3 md:py-5"
+            class="page-button orange-button mobile:h-auto md:w-[350px] px-5 py-3"
           >
             Start Your Accessibility Test
           </a>
@@ -210,11 +210,12 @@ import GamesShowcase from './GamesToLife/GamesShowcase.vue';
 
     <!-- Who We Work With Section -->
     <div
-      class="relative flex flex-col items-center justify-start mobile:justify-center w-full h-auto my-10 p-12"
+      class="relative flex flex-col items-center justify-start mobile:justify-center w-full h-auto my-10 sm:p-12"
     >
       <div class="w-full">
         <h2 class="game-resource-header">Who We Work With</h2>
         <PageDecorations
+          class="hidden sm:block"
           topRightImgPath="/assets/images/studio/sparkles.png"
           bottomLeftImgPath="/assets/images/studio/shooting-stars.png"
         />
@@ -375,8 +376,8 @@ import GamesShowcase from './GamesToLife/GamesShowcase.vue';
 
     <!-- Final Call to Action Section -->
     <div class="mobile:w-[90%] mx-auto bg-white p-5 my-10">
-      <div class="p-16 relative">
-        <PageDecorations />
+      <div class="sm:p-16 relative">
+        <PageDecorations class="hidden sm:block" />
         <h1 class="game-resource-header">
           <p>
             Make your game
@@ -386,11 +387,11 @@ import GamesShowcase from './GamesToLife/GamesShowcase.vue';
           <p>Let's talk.</p>
         </h1>
         <!-- Book Test Button -->
-        <div class="game-resource-btn-flex">
+        <div class="page-button-flex">
           <a
             href="mailto:connect@audemy.org"
             target="_blank"
-            class="game-resource-base-btn blue-button h-[70px] tablet:h-[60px] py-3 md:py-5"
+            class="page-button blue-button mobile:h-auto sm:w-[350px] px-5 py-3"
           >
             Book Your Free Test
           </a>

--- a/src/pages/AudioConsole/AudioConsole.vue
+++ b/src/pages/AudioConsole/AudioConsole.vue
@@ -60,7 +60,7 @@ const finalArrowClasses = [
       aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 1440 320"
-      class="absolute -z-10 left-0 top-0 scale-y-[-1]"
+      class="absolute -z-10 left-0 top-0 scale-y-[-1] w-full"
     >
       <path
         fill="#e7f0f5"
@@ -99,10 +99,10 @@ const finalArrowClasses = [
         </div>
 
         <!-- Learn More Button -->
-        <div class="game-resource-btn-flex">
+        <div class="page-button-flex">
           <a
             href="#learn-more"
-            class="game-resource-base-btn orange-button mx-auto h-[70px] tablet:h-[60px] mobile:px-5 py-3 md:py-5"
+            class="page-button orange-button mobile:h-auto w-[180px] sm:w-[350px] px-5 py-3"
           >
             Learn More
           </a>
@@ -223,11 +223,12 @@ const finalArrowClasses = [
 
     <!-- Grant + Pilot Information Section -->
     <div
-      class="relative flex flex-col items-center justify-start mobile:justify-center w-full h-auto my-10 p-12"
+      class="relative flex flex-col items-center justify-start mobile:justify-center w-full h-auto my-10 sm:p-12"
     >
       <div class="w-full">
         <h2 class="game-resource-header">Grant & Pilot Information</h2>
         <PageDecorations
+          class="hidden sm:block"
           :topRightImgPath="Sparkles"
           :bottomLeftImgPath="ShootingStars"
         />
@@ -391,8 +392,9 @@ const finalArrowClasses = [
         :class="[arrowClasses, finalArrowClasses]"
         aria-hidden="true"
       />
-      <div class="p-16 relative">
+      <div class="sm:p-16 relative">
         <PageDecorations
+          class="hidden sm:block"
           :topLeftImgPath="YellowStar"
           :bottomRightImgPath="YellowStar"
           :topRightImgPath="OrangeStar"
@@ -410,11 +412,11 @@ const finalArrowClasses = [
         </h1>
 
         <!-- Learn More Button -->
-        <div class="game-resource-btn-flex">
+        <div class="page-button-flex">
           <a
             href="mailto:connect@audemy.org"
             target="_blank"
-            class="game-resource-base-btn blue-button h-[70px] tablet:h-[60px] py-3 md:py-5"
+            class="page-button blue-button mobile:h-auto w-[180px] sm:w-[350px] px-5 py-3"
           >
             Learn More
           </a>

--- a/src/pages/GameToolkit/GameToolkit.vue
+++ b/src/pages/GameToolkit/GameToolkit.vue
@@ -1280,10 +1280,10 @@ const openToolkitPDF = (pdfUrl, gameName) => {
               </div>
             </button>
           </div>
-          <div class="md:mx-auto flex justify-center items-center my-16 mx-10">
+          <div class="page-button-flex">
             <a
               href="#toolkit-database"
-              class="game-resource-base-btn blue-button h-[70px] tablet:h-[60px] py-3 md:py-5"
+              class="page-button blue-button mobile:h-auto mobile:w-[80%] sm:w-[300px] px-5 py-3"
             >
               View All Toolkits
             </a>
@@ -1354,10 +1354,11 @@ const openToolkitPDF = (pdfUrl, gameName) => {
 
     <!-- Call to Action Section -->
     <div
-      class="flex flex-col items-center justify-center mobile:justify-center w-full h-auto py-10 md:py-10 my-10"
+      class="flex flex-col items-center justify-center mobile:justify-center w-full h-auto sm:py-10 my-10"
     >
-      <div class="w-full relative p-16">
+      <div class="w-full relative sm:p-16">
         <PageDecorations
+          class="hidden sm:block"
           topRightImgPath="/assets/images/game-toolkit/game-control.png"
           bottomLeftImgPath="/assets/images/game-toolkit/game-console.png"
         />
@@ -1368,20 +1369,24 @@ const openToolkitPDF = (pdfUrl, gameName) => {
           >
         </h2>
         <div
-          class="md:mx-auto flex justify-center items-center my-16 mx-10 gap-y-10 flex-col md:flex-row md:gap-16"
+          class="w-full mx-auto flex justify-center items-center my-16 mx-10 gap-y-10 flex-col md:flex-row md:gap-16"
         >
-          <a
-            href="#toolkit-database"
-            class="game-resource-base-btn orange-button h-[70px] tablet:h-[60px] mobile:px-5 py-3 md:py-5"
-          >
-            Download a Toolkit
-          </a>
-          <a
-            href="/accessibility-studio"
-            class="game-resource-base-btn blue-button h-[70px] tablet:h-[60px] py-3 md:py-5"
-          >
-            Partner with Us
-          </a>
+          <div class="flex flex-col">
+            <a
+              href="#toolkit-database"
+              class="page-button orange-button mobile:h-auto sm:w-[300px] px-5 py-3"
+            >
+              Download a Toolkit
+            </a>
+          </div>
+          <div class="flex flex-col">
+            <a
+              href="/accessibility-studio"
+              class="page-button blue-button mobile:h-auto sm:w-[300px] px-8 py-3"
+            >
+              Partner with Us
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/Home/Events/Events.vue
+++ b/src/pages/Home/Events/Events.vue
@@ -91,11 +91,11 @@ onUnmounted(() => {
             Our accessibility-focused hackathon that inspires innovation for
             people with disabilities.
           </p>
-          <div class="flex justify-center mt-4">
+          <div class="page-button-flex">
             <a
               href="https://katyhacks.org/"
               target="_blank"
-              class="font-poppins font-[600] w-[280px] tablet:w-full mobile:w-[90%] h-[56px] mobile:h-[56px] leading-[56px] tablet:h-[60px] tablet:leading-[60px] border-[1.5px] border-[#0C0D0D] rounded-[8px] bg-[#FE892A] hover:bg-[#D6711F] text-[16px] text-center text-[#0D0C0C] shadow-[4px_4px_0px_#0C0D0D]"
+              class="page-button orange-button"
             >
               Check upcoming events
             </a>

--- a/src/pages/Home/Hero/Hero.vue
+++ b/src/pages/Home/Hero/Hero.vue
@@ -33,7 +33,7 @@
       <div class="page-button-flex">
         <a
           href="/game-zone-landing-page"
-          class="page-button orange-button w-[280px] mx-auto text-center p-4"
+          class="page-button orange-button px-9 mobile:h-auto md:w-[300px] py-3"
         >
           Play our games!
         </a>

--- a/src/pages/Home/Impact/Impact.vue
+++ b/src/pages/Home/Impact/Impact.vue
@@ -28,7 +28,7 @@ import Globe from '/assets/images/impact/globe 1.svg';
       <div class="page-button-flex">
         <a
           href="/impact"
-          class="page-button blue-button w-[350px] mobile:w-[280px] mobile:h-[75px] py-3 px-16 text-center"
+          class="page-button blue-button mobile:h-auto md:w-[300px] py-3 px-4"
         >
           Explore our impact further
         </a>

--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -186,10 +186,10 @@ let videoStoped = () => {
           platform!
         </p>
 
-        <div class="flex text-center my-10">
+        <div class="page-button-flex">
           <a
             href="our-projects"
-            class="mx-auto page-button blue-button w-[300px] py-3 ease-in"
+            class="page-button blue-button px-9 mobile:h-auto py-3 md:w-[300px]"
           >
             Discover more
           </a>

--- a/src/pages/Impact/CollaboratingSchools/CollaboratingSchools.vue
+++ b/src/pages/Impact/CollaboratingSchools/CollaboratingSchools.vue
@@ -78,11 +78,11 @@ const arrowClasses = [
           on this exciting journey!
         </p>
       </div>
-      <div class="w-full md:w-1/2 text-center">
+      <div class="w-full md:w-1/2 page-button-flex">
         <a
           href="mailto:connect@audemy.org"
           target="_blank"
-          class="w-[250px] py-5 px-16 page-button blue-button"
+          class="page-button blue-button md:px-3 md:w-[300px] px-9 mobile:h-auto py-3"
         >
           Get affiliated
         </a>

--- a/src/pages/Impact/PressList/PressList.vue
+++ b/src/pages/Impact/PressList/PressList.vue
@@ -219,15 +219,12 @@ onUnmounted(() => {
       <div class="w-full py-5 md:my-10">
         <!-- Header -->
         <div>
-          <h3
-            class="text-small-text-color text-[12px] text-[#899296] font-[600] text-center tracking-[3.6px]"
-          >
-            PRESS LIST
-          </h3>
+          <h3 class="page-header-accent">PRESS LIST</h3>
         </div>
         <div>
           <h2 class="page-header">
-            Trusted by <em style="color: #fe892a"> Leading Publications </em>
+            Trusted by
+            <em class="text-secondary-color"> Leading Publications </em>
           </h2>
         </div>
       </div>
@@ -268,10 +265,10 @@ onUnmounted(() => {
           </div>
 
           <!-- Show More/Less Button -->
-          <div class="flex justify-center mb-[31px]">
+          <div class="page-button-flex">
             <button
               @click="toggleShowAll"
-              class="w-[244px] mobile:w-auto font-semibold px-[4.20rem] py-4 border-[1.5px] border-[#0C0D0D] rounded-[8px] bg-primary-color hover:bg-[#0C587D] duration-300 text-base text-white shadow-[3px_4px_0px_#0C0D0D]"
+              class="page-button blue-button px-10 py-3 mobile:h-auto md:w-[300px]"
             >
               {{ showAll ? 'Show Less' : 'See More' }}
             </button>

--- a/src/pages/OurProjects/Events/HaveYouHeard/HaveYouHeard.vue
+++ b/src/pages/OurProjects/Events/HaveYouHeard/HaveYouHeard.vue
@@ -48,11 +48,11 @@ const items = [
           />
         </div>
       </div>
-      <div class="flex items-center justify-center my-10 text-center">
+      <div class="page-button-flex">
         <a
           href="https://www.instagram.com/audemyapp/"
           target="_blank"
-          class="page-button blue-button px-9 mobile:h-auto py-3"
+          class="page-button blue-button px-9 py-3 mobile:h-auto md:w-[300px]"
         >
           Follow us on Instagram
         </a>

--- a/src/pages/OurProjects/Events/KatyYouthHacks/KatyYouthHacks.vue
+++ b/src/pages/OurProjects/Events/KatyYouthHacks/KatyYouthHacks.vue
@@ -6,7 +6,7 @@
     - Medium+: Row; Carl image (left) & text (right)
   -->
   <div
-    class="relative w-full flex flex-col md:flex-row font-poppins p-10 gap-y-5 md:gap-y-0"
+    class="relative w-full flex flex-col md:flex-row font-poppins p-3 md:p-10 gap-y-5 md:gap-y-0"
   >
     <!-- DECORATIVE BG PATTERN -->
     <img
@@ -51,11 +51,11 @@
           </p>
         </div>
       </div>
-      <div class="flex justify-center md:justify-start mt-5">
+      <div class="page-button-flex justify-center md:justify-start">
         <a
           href="https://katyhacks.org/"
           target="_blank"
-          class="page-button orange-button px-9 py-3"
+          class="page-button orange-button text-center md:px-3 md:w-[280px] px-9 mobile:h-auto py-3"
         >
           Check upcoming events
         </a>

--- a/src/pages/OurProjects/ResearchTech/ResearchTech.vue
+++ b/src/pages/OurProjects/ResearchTech/ResearchTech.vue
@@ -105,10 +105,10 @@ const items2 = [
       </div>
     </div>
 
-    <div class="flex items-center justify-center mt-10 text-center">
+    <div class="page-button-flex">
       <a
         href="/game-zone-landing-page"
-        class="page-button blue-button w-[244px] px-9 py-4"
+        class="page-button blue-button md:px-3 md:w-[300px] px-9 mobile:h-auto py-3"
       >
         Try out our games!
       </a>

--- a/src/pages/OurProjects/Social/SocialMedia.vue
+++ b/src/pages/OurProjects/Social/SocialMedia.vue
@@ -6,7 +6,7 @@
       :class="[
         'h-[40px] sm:h-[50px] md:h-[60px] lg:h-[70px]',
         'absolute z-40',
-        'right-0 bottom-[18%]',
+        'right-0 bottom-[20%]',
         'sm:bottom-[10%] sm:right-[10%]',
         'md:bottom-20',
         'lg:bottom-1/2 lg:right-[-5%]',
@@ -54,11 +54,11 @@
         </div>
       </div>
     </div>
-    <div class="flex justify-center mt-10">
+    <div class="page-button-flex">
       <a
         href="https://www.youtube.com/@applelooeducationalvideosf1743/featured"
         target="_blank"
-        class="page-button blue-button page-button-flex px-9 py-4"
+        class="page-button blue-button mobile:h-auto md:w-[300px] px-9 md:px-3 py-3"
       >
         Watch more videos
       </a>

--- a/src/style.css
+++ b/src/style.css
@@ -13,7 +13,7 @@
 
 /* --- Buttons --- */
 .page-button {
-  @apply h-[55px] font-bold rounded-lg border-2 border-black shadow-[4px_4px_0px_black] duration-300;
+  @apply text-center h-[55px] font-bold rounded-lg border-2 border-black shadow-[4px_4px_0px_black] duration-300;
 }
 
 .blue-button {

--- a/src/style.css
+++ b/src/style.css
@@ -13,7 +13,7 @@
 
 /* --- Buttons --- */
 .page-button {
-  @apply text-center h-[55px] font-bold rounded-lg border-2 border-black shadow-[4px_4px_0px_black] duration-300;
+  @apply text-center h-[55px] font-bold rounded-lg border-2 border-black shadow-[4px_4px_0px_black] ease-in duration-300;
 }
 
 .blue-button {
@@ -25,7 +25,7 @@
 }
 
 .page-button-flex {
-  @apply flex mobile:flex-col justify-center items-center my-10;
+  @apply flex mobile:flex-col justify-center items-center text-center my-10;
 }
 
 /* --- Pattern: White bg with grey crossed-lines --- */


### PR DESCRIPTION
# Summary

- Fix RWD for sitewide buttons, especially on mobile
  - Apply `flex` rules & fix mobile and medium RWD 
- Hide decorative `<PageDecorations/>` on mobile for better spacing
- Minor Refactors: 
  - Add DRY UI buttons & remove redundant Tailwind classes

## Table of changes

<details><summary>View</summary>

| Modified Page / File | Relevant <kbd>Buttons</kbd> / Changes |
| :--- | :--- |
| "Buzzle" Page | - <kbd>"Learn More"</kbd> (x2; orange & blue) <br> - SVG wave |
| "Game Toolkits" Page | - <kbd>"View All"</kbd> <br> - <kbd>"Download a Toolkit"</kbd> <br> - <kbd>"Partner with Us"</kbd> |
| "Accessibility Studio" Page | - <kbd>"Start Your Accessibility Test"</kbd> <br> - <kbd>"Book Your Free Test"</kbd> |
| `game-resource-style.css` | - Removed redundant classes |
| "Home" Page | - <kbd>"Play our games"</kbd> <br> - <kbd>"Explore our impact further"</kbd> <br> - <kbd>"Discover more"</kbd> <br> - <kbd>"See More"</kbd>/<kbd>"Show Less"</kbd> |
| "Impact" Page | - <kbd>"Get Affiliated"</kbd> <br> - <kbd>"Check upcoming Events"</kbd> <br> - <kbd>"Try out our games"</kbd> <br> - <kbd>"Watch more videos"</kbd> |

</details>

---

# Before & After Demos

## Fix: Button RWD 

<details>
  <summary>View Samples</summary>

| Before: Mobile | Before: Desktop Resizing at `350px`| After: RWD Fix |
| :---: |:---: | :---:|
| <img width="300" alt="before rwd bug live mobile" src="https://github.com/user-attachments/assets/2b416ea2-205c-4ffd-ba6d-e463ab621289" /> | <img width="300" alt="350px resizing live rwd bug" src="https://github.com/user-attachments/assets/dbda6837-a760-433e-a714-e3d164d6c51e" />  |  <img width="300" alt="350px after rwd" src="https://github.com/user-attachments/assets/a2bef851-1d7e-44c2-824a-afb072249ff4" /> | 

</details>

## Fix: Hide `<PageDecorations/>` on mobile

<details>
  <summary>View Accessibility Studio</summary>

### Access. Studio 
| Before: Narrow Text | After: Improved Spacing |
| :---: |:---: |
|<img height="300" alt="350px live narrow text" src="https://github.com/user-attachments/assets/42c4d774-01c6-448f-bddc-18bf0e21befa" /> |  <img height="300"  alt="350px hide deco" src="https://github.com/user-attachments/assets/dc2d7ec5-8fd1-41c9-bef1-16d97fe53dd0" /> |
| <img height="300"  alt="350px live narrow text 2" src="https://github.com/user-attachments/assets/be2e20d5-98f4-4e60-901d-cb6865452c43" /> |  <img height="300"  alt="350px hide deco 2" src="https://github.com/user-attachments/assets/e7b6cbba-8b40-4fb2-bc41-94fe714492df" />|

</details>

---

<details>
  <summary>View Game Toolkits</summary>

### Game Toolkits
| Before <br> (shown at `300px` to show impact) | After <br>RWD Fix & Improved Spacing |
| :---: |:---: |
|  <img width="301" height="754" alt="300px before" src="https://github.com/user-attachments/assets/0e2fe367-d5dd-448f-af9e-d8abbc282a07" /> |  <img width="301" height="755" alt="300px after rwd fix" src="https://github.com/user-attachments/assets/73cc70b9-e7f5-4e78-9ec1-5c6c8bad257f" />|

</details>

---

# Manual Tests
- Local via `vercel dev`
- RWD from `350px` (mobile simulation via desktop resizing) to `1680px` (2xl)
- All affected buttons remain functional