### PR TITLE
fix: Captions Timing on Mobile & Tablet (+ UI Refactor)

### DIFF
--- a/public/assets/questionsDb/definitionDetectiveDB.json
+++ b/public/assets/questionsDb/definitionDetectiveDB.json
@@ -16,7 +16,7 @@
         },
         {
           "Q": "What is the word for a round object used in many sports, like soccer and basketball?",
-          "A": ["ball", "bawl"]
+          "A": ["ball"]
         },
         {
           "Q": "What is the word for a big red fruit with seeds inside, often made into sauce?",
@@ -40,7 +40,7 @@
         },
         {
           "Q": "What is the word for a person who teaches in a school?",
-          "A": ["teacher", "teach her"]
+          "A": ["teacher"]
         },
         {
           "Q": "What is the word for something you wear on your feet?",
@@ -102,7 +102,7 @@
       "Medium": [
         {
           "Q": "What is the word for a place where books are kept and borrowed?",
-          "A": ["library", "lie berry"]
+          "A": ["library"]
         },
         {
           "Q": "What is the word for a person who flies an airplane?",

--- a/public/assets/questionsDb/syllableGameDB.json
+++ b/public/assets/questionsDb/syllableGameDB.json
@@ -2,177 +2,231 @@
   "SyllableCountingGame": {
     "Questions": {
       "Easy": [
-        { "Q": "How many syllables are in the word 'apple'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'orange'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'banana'?", "A": ["three"] },
-        { "Q": "How many syllables are in the word 'cat'?", "A": ["one"] },
-        { "Q": "How many syllables are in the word 'dog'?", "A": ["one"] },
-        { "Q": "How many syllables are in the word 'happy'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'house'?", "A": ["one"] },
-        { "Q": "How many syllables are in the word 'tiger'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'school'?", "A": ["one"] },
-        { "Q": "How many syllables are in the word 'purple'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'pencil'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'balloon'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'guitar'?", "A": ["two"] },
+        {
+          "Q": "How many syllables are in the word 'apple'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'orange'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'banana'?",
+          "A": ["three", "3"]
+        },
+        { "Q": "How many syllables are in the word 'cat'?", "A": ["one", "1"] },
+        { "Q": "How many syllables are in the word 'dog'?", "A": ["one", "1"] },
+        {
+          "Q": "How many syllables are in the word 'happy'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'house'?",
+          "A": ["one", "1"]
+        },
+        {
+          "Q": "How many syllables are in the word 'tiger'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'school'?",
+          "A": ["one", "1"]
+        },
+        {
+          "Q": "How many syllables are in the word 'purple'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'pencil'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'balloon'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'guitar'?",
+          "A": ["two", "2"]
+        },
         {
           "Q": "How many syllables are in the word 'elephant'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
-        { "Q": "How many syllables are in the word 'tiger'?", "A": ["two"] },
+        {
+          "Q": "How many syllables are in the word 'tiger'?",
+          "A": ["two", "2"]
+        },
         {
           "Q": "How many syllables are in the word 'butterfly'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
-        { "Q": "How many syllables are in the word 'ocean'?", "A": ["two"] },
+        {
+          "Q": "How many syllables are in the word 'ocean'?",
+          "A": ["two", "2"]
+        },
         {
           "Q": "How many syllables are in the word 'sunflower'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'computer'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         }
       ],
       "Medium": [
         {
           "Q": "How many syllables are in the word 'elephant'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'chocolate'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
-        { "Q": "How many syllables are in the word 'giraffe'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'balloon'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'mountain'?", "A": ["two"] },
+        {
+          "Q": "How many syllables are in the word 'giraffe'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'balloon'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'mountain'?",
+          "A": ["two", "2"]
+        },
         {
           "Q": "How many syllables are in the word 'butterfly'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'hamburger'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'umbrella'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
-        { "Q": "How many syllables are in the word 'pencil'?", "A": ["two"] },
-        { "Q": "How many syllables are in the word 'jungle'?", "A": ["two"] },
+        {
+          "Q": "How many syllables are in the word 'pencil'?",
+          "A": ["two", "2"]
+        },
+        {
+          "Q": "How many syllables are in the word 'jungle'?",
+          "A": ["two", "2"]
+        },
         {
           "Q": "How many syllables are in the word 'computer'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'calendar'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'caterpillar'?",
-          "A": ["four"]
+          "A": ["four", "4"]
         },
         {
           "Q": "How many syllables are in the word 'unicorn'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'submarine'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'alligator'?",
-          "A": ["four"]
+          "A": ["four", "4"]
         },
         {
           "Q": "How many syllables are in the word 'grapefruit'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'celebrate'?",
-          "A": ["three"]
+          "A": ["three", "3"]
         },
         {
           "Q": "How many syllables are in the word 'dictionary'?",
-          "A": ["four"]
+          "A": ["four", "4"]
         }
       ],
       "Hard": [
         {
           "Q": "How many syllables are in the word 'determination'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'vocabulary'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'unbelievable'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'communication'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'organization'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'electricity'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'international'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'magnificent'?",
-          "A": ["four"]
+          "A": ["four", "4"]
         },
         {
           "Q": "How many syllables are in the word 'comprehensive'?",
-          "A": ["four"]
+          "A": ["four", "4"]
         },
         {
           "Q": "How many syllables are in the word 'hypothetical'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'hippopotamus'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'counterproductive'?",
-          "A": ["six"]
+          "A": ["six", "6"]
         },
         {
           "Q": "How many syllables are in the word 'uncharacteristically'?",
-          "A": ["seven"]
+          "A": ["seven", "7"]
         },
         {
           "Q": "How many syllables are in the word 'misunderstanding'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'unquestionably'?",
-          "A": ["four"]
+          "A": ["four", "4"]
         },
         {
           "Q": "How many syllables are in the word 'unbelievably'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         },
         {
           "Q": "How many syllables are in the word 'extraordinarily'?",
-          "A": ["six"]
+          "A": ["six", "6"]
         },
         {
           "Q": "How many syllables are in the word 'disproportionately'?",
-          "A": ["six"]
+          "A": ["six", "6"]
         },
         {
           "Q": "How many syllables are in the word 'overwhelmingly'?",
-          "A": ["five"]
+          "A": ["five", "5"]
         }
       ]
     }

--- a/src/components/Game/AnswerCaptions.vue
+++ b/src/components/Game/AnswerCaptions.vue
@@ -13,7 +13,7 @@ import {
 
 /* --- PROPS --- */
 
-defineProps({
+const props = defineProps({
   title: {
     type: String,
     required: true,

--- a/src/components/Game/AnswerCaptions.vue
+++ b/src/components/Game/AnswerCaptions.vue
@@ -6,6 +6,9 @@
  */
 
 /* --- IMPORTS --- */
+
+import { computed } from 'vue';
+
 import {
   feedbackClasses,
   transparentBgClasses,
@@ -42,6 +45,24 @@ const props = defineProps({
     required: false,
     default: '',
   },
+});
+
+/* --- COMPUTED PROPERTIES --- */
+
+// Compute final answer captions
+const captionText = computed(() => {
+  if (props.title === 'Car Counting') {
+    // 1. Check special case: 'Car Counting'
+    // - Game passes 'getCurrentAnswer()' return value as 'currentQuestion' prop
+    return props.currentQuestion;
+  } else if (props.firstMatchingAnswer !== '') {
+    // 2. Check if game accepts answers with synonyms or numbers
+    // - Align answer UI captions with transcript
+    return props.firstMatchingAnswer;
+  } else {
+    // 3. Default: First answer choice
+    return props.currentQuestion['A'][0];
+  }
 });
 </script>
 
@@ -98,17 +119,7 @@ const props = defineProps({
           </p>
           <p>
             <span class="font-semibold"> Answer: </span>
-            <!-- 1. Check special case: 'Car Counting' 
-                    - Game passes 'getCurrentAnswer()' return value as 'currentQuestion' prop 
-                  -->
-            <!-- 2. Check if game accepts answers with synonyms or numbers -->
-            {{
-              title == 'Car Counting' // Check #1
-                ? currentQuestion
-                : firstMatchingAnswer !== '' // Check #2
-                  ? firstMatchingAnswer
-                  : currentQuestion['A'][0]
-            }}
+            {{ captionText }}
           </p>
         </div>
       </div>

--- a/src/components/Game/AnswerCaptions.vue
+++ b/src/components/Game/AnswerCaptions.vue
@@ -1,0 +1,117 @@
+<script setup>
+/*
+ * AnswerCaptions.vue:
+ * - Dynamic, timed captions for game answers and user feedback
+ * - Used in <GameHeader/> as a visual alternative to audio-based feedback
+ */
+
+/* --- IMPORTS --- */
+import {
+  feedbackClasses,
+  transparentBgClasses,
+} from './GameHeaderConstants.js';
+
+/* --- PROPS --- */
+
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  /* currentQuestion: Captions for current game question */
+  currentQuestion: {
+    type: Object,
+    required: false,
+    default: null,
+  },
+  /* isCorrect (flag): 
+  - True: If user answer is correct 
+  - Controlled & returned by useGameCore.js: toggleRecording() 
+  */
+  isCorrect: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  /* firstMatchingAnswer: 
+  - Accounts for answers with synonyms or number formats (eg. plurality, '3' vs 'three')
+  - Controlled & returned by useGameQuestions.js: validateAnswer() 
+  */
+  firstMatchingAnswer: {
+    type: String,
+    required: false,
+    default: '',
+  },
+});
+</script>
+
+<template>
+  <div
+    aria-hidden="true"
+    class="flex flex-col items-center justify-center gap-y-5 w-full"
+  >
+    <div
+      class="flex flex-col md:flex-row items-center w-full md:items-stretch rounded-[16px] shadow-md"
+    >
+      <div
+        :class="[
+          feedbackClasses,
+          isCorrect ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-800',
+        ]"
+      >
+        <span v-if="isCorrect">
+          <img
+            aria-hidden="true"
+            src="/assets/gameImages/correct.png"
+            class="h-[25px] md:h-[35px]"
+          />
+        </span>
+        <span v-else>
+          <img
+            aria-hidden="true"
+            src="/assets/gameImages/wrong.png"
+            class="h-[25px] md:h-[35px]"
+          />
+        </span>
+      </div>
+      <div
+        class="relative w-full md:w-3/4 p-2 flex flex-col items-center justify-center"
+      >
+        <!-- Decorative transparent background for answer legibility -->
+        <div
+          aria-hidden="true"
+          :class="[
+            transparentBgClasses,
+            'rounded-b-[16px] md:rounded-l-[0px] md:rounded-r-[16px]',
+          ]"
+        ></div>
+        <div
+          class="relative flex flex-col gap-y-2 z-10 text-[15.5px] md:text-[16px] 2xl:text-[20px]"
+        >
+          <p
+            :class="[
+              'font-semibold',
+              isCorrect ? 'text-green-700' : 'text-red-800',
+            ]"
+          >
+            {{ isCorrect ? 'Correct!' : 'Incorrect!' }}
+          </p>
+          <p>
+            <span class="font-semibold"> Answer: </span>
+            <!-- 1. Check special case: 'Car Counting' 
+                    - Game passes 'getCurrentAnswer()' return value as 'currentQuestion' prop 
+                  -->
+            <!-- 2. Check if game accepts answers with synonyms or numbers -->
+            {{
+              title == 'Car Counting' // Check #1
+                ? currentQuestion
+                : firstMatchingAnswer !== '' // Check #2
+                  ? firstMatchingAnswer
+                  : currentQuestion['A'][0]
+            }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/Game/GameControls.vue
+++ b/src/components/Game/GameControls.vue
@@ -169,10 +169,7 @@ const props = defineProps({
 });
 
 const showControls = computed(() => {
-  return (
-    !(props.isTablet || props.isMobile) ||
-    (!props.isIntroPlaying && props.numOfAudiosPlayed > 0)
-  );
+  return !props.isIntroPlaying && props.numOfAudiosPlayed > 0;
 });
 
 const emits = defineEmits(['record-click', 'repeat-click']);

--- a/src/components/Game/GameControls.vue
+++ b/src/components/Game/GameControls.vue
@@ -47,7 +47,7 @@
         'bg-white border border-[#0096D6] text-[#0096D6]',
         isIntroPlaying || isButtonCooldown
           ? 'opacity-50 cursor-not-allowed'
-          : '',
+          : 'hover:bg-gray-200',
       ]"
       :disabled="isIntroPlaying || isButtonCooldown"
       :title="

--- a/src/components/Game/GameHeader.vue
+++ b/src/components/Game/GameHeader.vue
@@ -200,79 +200,16 @@
 </template>
 
 <script setup>
-/* --- EXTRACTED RWD & STYLE CLASSES --- */
+/* --- IMPORTS --- */
 
-// RWD classes for outermost <GameHeader/> wrapper
-const gameHeaderClasses = [
-  'relative', // RWD & positioning layout
-  'flex',
-  'flex-col',
-  'items-center',
-  'mobile:w-[70%]', // RWD size
-  'w-[400px]',
-  'md:w-full',
-  'bg-cross-lines', // Styling & spacing
-  'py-5',
-  'px-12',
-  'md:p-10',
-  'my-2',
-  'md:my-5',
-  'rounded-[16px]',
-  'shadow-md',
-];
-
-// RWD classes for multiple-choice captions
-const multipleChoiceClasses = [
-  'bg-[#edf7fc]',
-  'rounded-full',
-  'p-0',
-  'md:p-1',
-  'my-3',
-  'ease-in',
-  'duration-300',
-  'w-full' /* Mobile & small screens: Column layout */,
-  'md:w-[45%]' /* Medium+ screens: Row layout */,
-];
-
-// RWD classes for user feedback message
-const feedbackClasses = [
-  'flex', // RWD
-  'gap-x-2',
-  'md:flex-col',
-  'items-center',
-  'justify-center',
-  'rounded-t-[16px]', // Styling, size, & text
-  'md:rounded-l-[16px]',
-  'md:rounded-r-[0px]',
-  'w-full',
-  'md:w-1/4',
-  'p-1',
-];
-
-// Shared RWD classes for background (behind captions)
-const transparentBgClasses = [
-  '-z-1',
-  'absolute',
-  'top-0',
-  'left-0',
-  'bg-white',
-  'w-full',
-  'h-full',
-  'opacity-70',
-  'rounded-b-[16px]',
-  'md:rounded-l-[0px]',
-  'md:rounded-r-[16px]',
-];
-
-/* --- CONSTANTS FOR MCQ & MULTI-PART QUESTION TYPES --- */
-
-const multipleChoiceGames = [
-  'Vocabulary Vortex',
-  'Polar Pairing',
-  'Odd One Out',
-];
-
-const multiPartsGames = ['Fruit Frenzy', 'Monkey Madness', 'Shape Shark'];
+import {
+  gameHeaderClasses,
+  multipleChoiceClasses,
+  feedbackClasses,
+  transparentBgClasses,
+  multipleChoiceGames,
+  multiPartsGames,
+} from './GameHeaderConstants.js';
 
 /* --- PROPS --- */
 

--- a/src/components/Game/GameHeader.vue
+++ b/src/components/Game/GameHeader.vue
@@ -1,29 +1,10 @@
 <template>
   <div :class="gameHeaderClasses">
     <!-- Decorative Question Progress Bar -->
-    <div
-      v-if="showCaptions"
-      aria-hidden="true"
-      class="flex flex-col items-center gap-y-3 w-full mb-3"
-    >
-      <div class="text-[14px] md:text-[15px] 2xl:text-[18px]">
-        <div class="flex gap-x-2">
-          <span class="hidden md:inline-block">Question</span>
-          <span class="inline-block md:hidden">Q</span>
-          <p class="inline-block mr-3">{{ currentQuestionIndex + 1 }} of 5</p>
-        </div>
-      </div>
-      <div class="flex w-full gap-x-3">
-        <div
-          v-for="n in 5"
-          :key="n"
-          class="w-1/5 h-[8px] rounded-[16px] border"
-          :class="[
-            n <= currentQuestionIndex + 1 ? 'bg-primary-color' : 'bg-[#edf7fc]',
-          ]"
-        ></div>
-      </div>
-    </div>
+    <GameProgressBar
+      :showCaptions="showCaptions"
+      :currentQuestionIndex="currentQuestionIndex"
+    />
     <div class="my-3">
       <!-- Icon RWD: 
         - Switch to bottom-left (mobile + small screens only)
@@ -210,6 +191,8 @@ import {
   multipleChoiceGames,
   multiPartsGames,
 } from './GameHeaderConstants.js';
+
+import GameProgressBar from './GameProgressBar.vue';
 
 /* --- PROPS --- */
 

--- a/src/components/Game/GameHeader.vue
+++ b/src/components/Game/GameHeader.vue
@@ -42,63 +42,13 @@
         aria-hidden="true"
         class="flex flex-col items-center gap-y-3"
       >
-        <div
+        <QuestionCaptions
           v-if="!isAnswerPlaying"
-          class="flex flex-col md:flex-row justify-center items-center md:items-stretch"
-        >
-          <div
-            class="relative text-[15.5px] md:text-[16px] 2xl:text-[20px] my-2 w-full"
-          >
-            <!-- Decorative transparent background for question legibility -->
-            <div
-              aria-hidden="true"
-              :class="[transparentBgClasses, '[rounded-[16px]']"
-            ></div>
-
-            <!-- 1. Special case: Format multiple-choice questions -->
-            <div
-              v-if="multipleChoiceGames.includes(title)"
-              class="relative z-10"
-            >
-              <p>{{ splitMCQs(currentQuestion['Q'])['question'] }}</p>
-              <!-- RWD: flex container for answer choices -->
-              <div class="px-10 flex flex-wrap justify-between items-center">
-                <div
-                  v-for="choice in splitMCQs(currentQuestion['Q'])['choices']"
-                  :key="choice"
-                  :class="multipleChoiceClasses"
-                >
-                  <p>{{ choice }}</p>
-                </div>
-              </div>
-            </div>
-
-            <!-- 2. Check if question has multiple parts (prompt + question) -->
-            <div
-              v-else-if="multiPartsGames.includes(title)"
-              class="relative z-10"
-            >
-              <!-- Split multiple part question for better readability -->
-              <p>{{ splitMultiPartsQs(currentQuestion['Q'])['prompt'] }}</p>
-              <p class="mt-3 md:mt-5">
-                {{ splitMultiPartsQs(currentQuestion['Q'])['question'] }}
-              </p>
-            </div>
-
-            <!-- 3. Fill in the blank question: Non-MCQ and Non-multiple parts game -->
-            <p v-else-if="!showAnswerOnly" class="relative z-10">
-              {{ currentQuestion['Q'] }}
-            </p>
-
-            <!-- 4. Otherwise: Show game description for 'Spelling Bee' & 'Car Counting' -->
-            <p
-              v-else-if="showAnswerOnly"
-              class="mobile:text-[16px] text-[18px] 2xl:text-[20px] relative z-10"
-            >
-              {{ description }}
-            </p>
-          </div>
-        </div>
+          :title="title"
+          :description="description"
+          :currentQuestion="currentQuestion"
+          :showAnswerOnly="showAnswerOnly"
+        />
 
         <!-- Show feedback & answer once final transcription is ready & validated -->
         <div
@@ -185,14 +135,12 @@
 
 import {
   gameHeaderClasses,
-  multipleChoiceClasses,
   feedbackClasses,
   transparentBgClasses,
-  multipleChoiceGames,
-  multiPartsGames,
 } from './GameHeaderConstants.js';
 
 import GameProgressBar from './GameProgressBar.vue';
+import QuestionCaptions from './QuestionCaptions.vue';
 
 /* --- PROPS --- */
 
@@ -273,48 +221,4 @@ defineProps({
     default: false,
   },
 });
-
-/* --- HELPER FUNCTIONS --- */
-
-/* splitMCQs():
- * - Helper function to handle multiple-choice game Q's
- * - Based on 'multipleChoiceGames' list
- */
-const splitMCQs = (fullQuestion) => {
-  // Expected format (fullQuestion): Question followed by list of answer choices
-  const questionParts = fullQuestion.split('?');
-
-  // Split removes '?' delimiter, so manually add char back in UI
-  const question = questionParts[0] + '?';
-
-  // Splits multiple-choice options by a comma delimiter
-  let choices = questionParts[1].split(',');
-
-  // Special case: Trim trailing 'or ' from last answer choice
-  // Ex: 'Independence, Liberty, Constraint, or Automony?'
-  let lastChoice = choices.at(-1);
-  if (lastChoice.includes('or ')) {
-    lastChoice = lastChoice.replace('or ', '');
-    // Concatenate subarrays
-    choices = choices.slice(0, -1).concat(lastChoice);
-  }
-
-  return { question, choices };
-};
-
-/* splitMultiPartsQs():
- * - Helper function to handle multiple-part game Q's
- * - Based on 'multiPartsGames' list
- */
-const splitMultiPartsQs = (fullQuestion) => {
-  // Expected format (fullQuestion): Prompt (sentence) followed by question
-  // Ex: 'There are 3 apples and 2 bananas. How many fruits are there in total?'
-
-  const questionParts = fullQuestion.split('.');
-  // Split removes '.' delimiter, so manually add char back in UI
-  const prompt = questionParts[0] + '.';
-  const question = questionParts[1];
-
-  return { prompt, question };
-};
 </script>

--- a/src/components/Game/GameHeader.vue
+++ b/src/components/Game/GameHeader.vue
@@ -77,7 +77,7 @@ import AnswerCaptions from './AnswerCaptions.vue';
 
 /* --- PROPS --- */
 
-defineProps({
+const props = defineProps({
   iconSrc: {
     type: String,
     required: true,

--- a/src/components/Game/GameHeader.vue
+++ b/src/components/Game/GameHeader.vue
@@ -51,77 +51,13 @@
         />
 
         <!-- Show feedback & answer once final transcription is ready & validated -->
-        <div
+        <AnswerCaptions
           v-if="isAnswerPlaying"
-          aria-hidden="true"
-          class="flex flex-col items-center justify-center gap-y-5 w-full"
-        >
-          <div
-            class="flex flex-col md:flex-row items-center w-full md:items-stretch rounded-[16px] shadow-md"
-          >
-            <div
-              :class="[
-                feedbackClasses,
-                isCorrect
-                  ? 'bg-green-100 text-green-700'
-                  : 'bg-red-100 text-red-800',
-              ]"
-            >
-              <span v-if="isCorrect">
-                <img
-                  aria-hidden="true"
-                  src="/assets/gameImages/correct.png"
-                  class="h-[25px] md:h-[35px]"
-                />
-              </span>
-              <span v-else>
-                <img
-                  aria-hidden="true"
-                  src="/assets/gameImages/wrong.png"
-                  class="h-[25px] md:h-[35px]"
-                />
-              </span>
-            </div>
-            <div
-              class="relative w-full md:w-3/4 p-2 flex flex-col items-center justify-center"
-            >
-              <!-- Decorative transparent background for answer legibility -->
-              <div
-                aria-hidden="true"
-                :class="[
-                  transparentBgClasses,
-                  'rounded-b-[16px] md:rounded-l-[0px] md:rounded-r-[16px]',
-                ]"
-              ></div>
-              <div
-                class="relative flex flex-col gap-y-2 z-10 text-[15.5px] md:text-[16px] 2xl:text-[20px]"
-              >
-                <p
-                  :class="[
-                    'font-semibold',
-                    isCorrect ? 'text-green-700' : 'text-red-800',
-                  ]"
-                >
-                  {{ isCorrect ? 'Correct!' : 'Incorrect!' }}
-                </p>
-                <p>
-                  <span class="font-semibold"> Answer: </span>
-                  <!-- 1. Check special case: 'Car Counting' 
-                    - Game passes 'getCurrentAnswer()' return value as 'currentQuestion' prop 
-                  -->
-                  <!-- 2. Check if game accepts answers with synonyms or numbers -->
-                  {{
-                    title == 'Car Counting' // Check #1
-                      ? currentQuestion
-                      : firstMatchingAnswer !== '' // Check #2
-                        ? firstMatchingAnswer
-                        : currentQuestion['A'][0]
-                  }}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
+          :title="title"
+          :currentQuestion="currentQuestion"
+          :isCorrect="isCorrect"
+          :firstMatchingAnswer="firstMatchingAnswer"
+        />
       </div>
       <p v-else class="mobile:text-[16px] text-[18px] 2xl:text-[20px]">
         {{ description }}
@@ -133,14 +69,11 @@
 <script setup>
 /* --- IMPORTS --- */
 
-import {
-  gameHeaderClasses,
-  feedbackClasses,
-  transparentBgClasses,
-} from './GameHeaderConstants.js';
+import { gameHeaderClasses } from './GameHeaderConstants.js';
 
 import GameProgressBar from './GameProgressBar.vue';
 import QuestionCaptions from './QuestionCaptions.vue';
+import AnswerCaptions from './AnswerCaptions.vue';
 
 /* --- PROPS --- */
 

--- a/src/components/Game/GameHeader.vue
+++ b/src/components/Game/GameHeader.vue
@@ -10,7 +10,7 @@
         <div class="flex gap-x-2">
           <span class="hidden md:inline-block">Question</span>
           <span class="inline-block md:hidden">Q</span>
-          <p class="inline-block mr-3">{{ numOfAudiosPlayed + 1 }} of 5</p>
+          <p class="inline-block mr-3">{{ currentQuestionIndex + 1 }} of 5</p>
         </div>
       </div>
       <div class="flex w-full gap-x-3">
@@ -19,7 +19,7 @@
           :key="n"
           class="w-1/5 h-[8px] rounded-[16px] border"
           :class="[
-            n <= numOfAudiosPlayed + 1 ? 'bg-primary-color' : 'bg-[#edf7fc]',
+            n <= currentQuestionIndex + 1 ? 'bg-primary-color' : 'bg-[#edf7fc]',
           ]"
         ></div>
       </div>
@@ -310,11 +310,11 @@ defineProps({
     required: false,
     default: null,
   },
-  /* numOfAudiosPlayed: Index for current question */
-  numOfAudiosPlayed: {
+  /* currentQuestionIndex: Index for current question */
+  currentQuestionIndex: {
     type: Number,
     required: false,
-    default: 1,
+    default: 0,
   },
   /* isAnswerPlaying (flag): 
   - True: If feedback audio is playing for current question 

--- a/src/components/Game/GameHeaderConstants.js
+++ b/src/components/Game/GameHeaderConstants.js
@@ -1,0 +1,83 @@
+/*
+ * GameHeaderConstants.js:
+ *
+ * - Extracted / shared UI classes & game title constants for <GameHeader/>
+ * - Improves <GameHeader/> script readability & maintainability
+ */
+
+/* --- EXTRACTED RWD & STYLE CLASSES --- */
+
+// RWD classes for outermost <GameHeader/> wrapper
+export const gameHeaderClasses = [
+  'relative', // RWD & positioning layout
+  'flex',
+  'flex-col',
+  'items-center',
+  'mobile:w-[70%]', // RWD size
+  'w-[400px]',
+  'md:w-full',
+  'bg-cross-lines', // Styling & spacing
+  'py-5',
+  'px-12',
+  'md:p-10',
+  'my-2',
+  'md:my-5',
+  'rounded-[16px]',
+  'shadow-md',
+];
+
+// RWD classes for multiple-choice captions
+export const multipleChoiceClasses = [
+  'bg-[#edf7fc]',
+  'rounded-full',
+  'p-0',
+  'md:p-1',
+  'my-3',
+  'ease-in',
+  'duration-300',
+  'w-full' /* Mobile & small screens: Column layout */,
+  'md:w-[45%]' /* Medium+ screens: Row layout */,
+];
+
+// RWD classes for user feedback message
+export const feedbackClasses = [
+  'flex', // RWD
+  'gap-x-2',
+  'md:flex-col',
+  'items-center',
+  'justify-center',
+  'rounded-t-[16px]', // Styling, size, & text
+  'md:rounded-l-[16px]',
+  'md:rounded-r-[0px]',
+  'w-full',
+  'md:w-1/4',
+  'p-1',
+];
+
+// Shared RWD classes for background (behind captions)
+export const transparentBgClasses = [
+  '-z-1',
+  'absolute',
+  'top-0',
+  'left-0',
+  'bg-white',
+  'w-full',
+  'h-full',
+  'opacity-70',
+  'rounded-b-[16px]',
+  'md:rounded-l-[0px]',
+  'md:rounded-r-[16px]',
+];
+
+/* --- CONSTANTS FOR MCQ & MULTI-PART QUESTION TYPES --- */
+export const multipleChoiceGames = [
+  'Vocabulary Vortex',
+  'Polar Pairing',
+  'Odd One Out',
+];
+
+export const multiPartsGames = [
+  'Fruit Frenzy',
+  'Monkey Madness',
+  'Shape Shark',
+];

--- a/src/components/Game/GameHeaderConstants.js
+++ b/src/components/Game/GameHeaderConstants.js
@@ -2,7 +2,7 @@
  * GameHeaderConstants.js:
  *
  * - Extracted, shared UI classes & game title constants for <GameHeader/> components
- * - Improves script readability & maintainability for: 
+ * - Improves script readability & maintainability for:
  *  - <GameHeader/>, <QuestionCaptions/>, & <AnswerCaptions/>
  */
 

--- a/src/components/Game/GameHeaderConstants.js
+++ b/src/components/Game/GameHeaderConstants.js
@@ -1,8 +1,9 @@
 /*
  * GameHeaderConstants.js:
  *
- * - Extracted / shared UI classes & game title constants for <GameHeader/>
- * - Improves <GameHeader/> script readability & maintainability
+ * - Extracted, shared UI classes & game title constants for <GameHeader/> components
+ * - Improves script readability & maintainability for: 
+ *  - <GameHeader/>, <QuestionCaptions/>, & <AnswerCaptions/>
  */
 
 /* --- EXTRACTED RWD & STYLE CLASSES --- */

--- a/src/components/Game/GameLayout.vue
+++ b/src/components/Game/GameLayout.vue
@@ -77,7 +77,7 @@
           <button @click="goBack">
             <img
               src="/assets/gameImages/buttons/arrow-back.svg"
-              class="bg-white border-2 rounded-lg border-black h-12 p-2 shadow-md hover:bg-gray-300"
+              class="border-2 rounded-lg border-black h-12 p-2 bg-white shadow-md hover:bg-gray-200 ease-in duration-300"
               alt="Back to Game Zone"
             />
           </button>
@@ -92,7 +92,7 @@
             <button @click="goBack">
               <img
                 src="/assets/gameImages/buttons/arrow-back.svg"
-                class="bg-white border-2 rounded-lg border-black h-12 p-2 shadow-md hover:bg-gray-300"
+                class="bg-white border-2 rounded-lg border-black h-12 p-2 shadow-md hover:bg-gray-200 ease-in duration-300"
                 alt="Back to Game Zone"
               />
             </button>

--- a/src/components/Game/GameProgressBar.vue
+++ b/src/components/Game/GameProgressBar.vue
@@ -1,0 +1,55 @@
+<script setup>
+/*
+ * GameProgressBar.vue:
+ * - Decorative, dynamic game progress bar UI
+ * - Used in <GameHeader/>
+ */
+
+/* --- PROPS --- */
+
+defineProps({
+  /* showCaptions: Flag to control visibility of Qns, feedback, & answers
+    - Set to 'true' if all 3 conditions met: 
+    - 1. Game is playing, 
+    - 2. Intro audio is completed, 
+    - 3. Game has remaining questions to be played
+  */
+  showCaptions: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  /* currentQuestionIndex: Index for current question */
+  currentQuestionIndex: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
+});
+</script>
+
+<template>
+  <div
+    v-if="showCaptions"
+    aria-hidden="true"
+    class="flex flex-col items-center gap-y-3 w-full mb-3"
+  >
+    <div class="text-[14px] md:text-[15px] 2xl:text-[18px]">
+      <div class="flex gap-x-2">
+        <span class="hidden md:inline-block">Question</span>
+        <span class="inline-block md:hidden">Q</span>
+        <p class="inline-block mr-3">{{ currentQuestionIndex + 1 }} of 5</p>
+      </div>
+    </div>
+    <div class="flex w-full gap-x-3">
+      <div
+        v-for="n in 5"
+        :key="n"
+        class="w-1/5 h-[8px] rounded-[16px] border"
+        :class="[
+          n <= currentQuestionIndex + 1 ? 'bg-primary-color' : 'bg-[#edf7fc]',
+        ]"
+      ></div>
+    </div>
+  </div>
+</template>

--- a/src/components/Game/GameProgressBar.vue
+++ b/src/components/Game/GameProgressBar.vue
@@ -7,7 +7,7 @@
 
 /* --- PROPS --- */
 
-defineProps({
+const props = defineProps({
   /* showCaptions: Flag to control visibility of Qns, feedback, & answers
     - Set to 'true' if all 3 conditions met: 
     - 1. Game is playing, 

--- a/src/components/Game/PlayButton.vue
+++ b/src/components/Game/PlayButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     @click="$emit('play-click')"
-    class="page-button text-nowrap bg-[#087bb4] text-white w-[50%]"
+    class="page-button text-nowrap blue-button w-[50%]"
   >
     Play
   </button>

--- a/src/components/Game/QuestionCaptions.vue
+++ b/src/components/Game/QuestionCaptions.vue
@@ -1,0 +1,141 @@
+<script setup>
+/*
+ * QuestionCaptions.vue:
+ * - Dynamic, timed captions for game questions
+ * - Used in <GameHeader/> as a visual alternative to audio-based Q's
+ */
+
+/* --- IMPORTS --- */
+
+import {
+  multipleChoiceClasses,
+  transparentBgClasses,
+  multipleChoiceGames,
+  multiPartsGames,
+} from './GameHeaderConstants.js';
+
+/* --- PROPS --- */
+
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    required: true,
+  },
+  /* currentQuestion: Captions for current game question */
+  currentQuestion: {
+    type: Object,
+    required: false,
+    default: null,
+  },
+  /* showAnswerOnly (flag): 
+  - True: Show answer & feedback captions only 
+  - Hide questions for 'Spelling Bee' & 'Car Counting' 
+  */
+  showAnswerOnly: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+});
+
+/* --- HELPER FUNCTIONS --- */
+
+/* splitMCQs():
+ * - Helper function to handle multiple-choice game Q's
+ * - Based on 'multipleChoiceGames' list
+ */
+const splitMCQs = (fullQuestion) => {
+  // Expected format (fullQuestion): Question followed by list of answer choices
+  const questionParts = fullQuestion.split('?');
+
+  // Split removes '?' delimiter, so manually add char back in UI
+  const question = questionParts[0] + '?';
+
+  // Splits multiple-choice options by a comma delimiter
+  let choices = questionParts[1].split(',');
+
+  // Special case: Trim trailing 'or ' from last answer choice
+  // Ex: 'Independence, Liberty, Constraint, or Automony?'
+  let lastChoice = choices.at(-1);
+  if (lastChoice.includes('or ')) {
+    lastChoice = lastChoice.replace('or ', '');
+    // Concatenate subarrays
+    choices = choices.slice(0, -1).concat(lastChoice);
+  }
+
+  return { question, choices };
+};
+
+/* splitMultiPartsQs():
+ * - Helper function to handle multiple-part game Q's
+ * - Based on 'multiPartsGames' list
+ */
+const splitMultiPartsQs = (fullQuestion) => {
+  // Expected format (fullQuestion): Prompt (sentence) followed by question
+  // Ex: 'There are 3 apples and 2 bananas. How many fruits are there in total?'
+
+  const questionParts = fullQuestion.split('.');
+  // Split removes '.' delimiter, so manually add char back in UI
+  const prompt = questionParts[0] + '.';
+  const question = questionParts[1];
+
+  return { prompt, question };
+};
+</script>
+
+<template>
+  <div
+    class="flex flex-col md:flex-row justify-center items-center md:items-stretch"
+  >
+    <div
+      class="relative text-[15.5px] md:text-[16px] 2xl:text-[20px] my-2 w-full"
+    >
+      <!-- Decorative transparent background for question legibility -->
+      <div
+        aria-hidden="true"
+        :class="[transparentBgClasses, '[rounded-[16px]']"
+      ></div>
+
+      <!-- 1. Special case: Format multiple-choice questions -->
+      <div v-if="multipleChoiceGames.includes(title)" class="relative z-10">
+        <p>{{ splitMCQs(currentQuestion['Q'])['question'] }}</p>
+        <!-- RWD: flex container for answer choices -->
+        <div class="px-10 flex flex-wrap justify-between items-center">
+          <div
+            v-for="choice in splitMCQs(currentQuestion['Q'])['choices']"
+            :key="choice"
+            :class="multipleChoiceClasses"
+          >
+            <p>{{ choice }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- 2. Check if question has multiple parts (prompt + question) -->
+      <div v-else-if="multiPartsGames.includes(title)" class="relative z-10">
+        <!-- Split multiple part question for better readability -->
+        <p>{{ splitMultiPartsQs(currentQuestion['Q'])['prompt'] }}</p>
+        <p class="mt-3 md:mt-5">
+          {{ splitMultiPartsQs(currentQuestion['Q'])['question'] }}
+        </p>
+      </div>
+
+      <!-- 3. Fill in the blank question: Non-MCQ and Non-multiple parts game -->
+      <p v-else-if="!showAnswerOnly" class="relative z-10">
+        {{ currentQuestion['Q'] }}
+      </p>
+
+      <!-- 4. Otherwise: Show game description for 'Spelling Bee' & 'Car Counting' -->
+      <p
+        v-else-if="showAnswerOnly"
+        class="mobile:text-[16px] text-[18px] 2xl:text-[20px] relative z-10"
+      >
+        {{ description }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/components/Game/QuestionCaptions.vue
+++ b/src/components/Game/QuestionCaptions.vue
@@ -16,7 +16,7 @@ import {
 
 /* --- PROPS --- */
 
-defineProps({
+const props = defineProps({
   title: {
     type: String,
     required: true,

--- a/src/components/Game/StartQuestionsButton.vue
+++ b/src/components/Game/StartQuestionsButton.vue
@@ -1,9 +1,11 @@
 <template>
   <button
     @click="$emit('start-click')"
-    class="page-button text-nowrap bg-[#087bb4] text-white px-10 w-full"
+    class="page-button text-nowrap bg-[#087BB4] text-white px-10 w-full"
     :disabled="isIntroPlaying"
-    :class="{ 'opacity-50 cursor-not-allowed': isIntroPlaying }"
+    :class="[
+      isIntroPlaying ? 'opacity-50 cursor-not-allowed' : 'hover:bg-[#0C587D]',
+    ]"
   >
     {{ isIntroPlaying ? 'Please wait...' : 'Start Questions' }}
   </button>

--- a/src/composables/useGameCore.js
+++ b/src/composables/useGameCore.js
@@ -54,7 +54,6 @@ export function useGameCore(gameConfig) {
 
   const numOfAudiosPlayed = computed(() => {
     if (
-      (gameUI.isTablet.value || gameUI.isMobile.value) &&
       hasStartedFirstQuestion.value &&
       gameQuestions.currentQuestionIndex.value === 0
     ) {
@@ -195,6 +194,9 @@ export function useGameCore(gameConfig) {
   const startFirstQuestion = () => {
     console.log('Starting first question...');
     hasStartedFirstQuestion.value = true;
+
+    // Remain at index 0
+    // since toggleRecording() calls moveToNextQuestion()
     playNextQuestion();
   };
 
@@ -238,9 +240,6 @@ export function useGameCore(gameConfig) {
             }
 
             isIntroPlaying.value = false;
-            if (gameUI.isDesktop.value) {
-              playNextQuestion();
-            }
           };
         } else {
           // Start the background music
@@ -253,9 +252,6 @@ export function useGameCore(gameConfig) {
           // Stop music after TTS intro
           stopMusic();
           isIntroPlaying.value = false;
-          if (gameUI.isDesktop.value) {
-            playNextQuestion();
-          }
         }
       }
     });
@@ -272,6 +268,7 @@ export function useGameCore(gameConfig) {
 
   return {
     numOfAudiosPlayed,
+    currentQuestionIndex: gameQuestions.currentQuestionIndex,
     score,
     isRecording,
     isFinalResult,

--- a/src/composables/useGameCore.js
+++ b/src/composables/useGameCore.js
@@ -24,6 +24,7 @@ export function useGameCore(gameConfig) {
   const playButton = ref(false);
   const isIntroPlaying = ref(false);
   const isButtonCooldown = ref(false);
+  const hasStartedFirstQuestion = ref(false);
 
   /* 
   isAnswerPlaying (flag): 
@@ -50,6 +51,17 @@ export function useGameCore(gameConfig) {
   };
 
   const gameUI = useGameUI(gameState);
+
+  const numOfAudiosPlayed = computed(() => {
+    if (
+      (gameUI.isTablet.value || gameUI.isMobile.value) &&
+      hasStartedFirstQuestion.value &&
+      gameQuestions.currentQuestionIndex.value === 0
+    ) {
+      return 1;
+    }
+    return gameQuestions.currentQuestionIndex.value;
+  });
 
   const playNextQuestion = async () => {
     if (
@@ -182,7 +194,7 @@ export function useGameCore(gameConfig) {
 
   const startFirstQuestion = () => {
     console.log('Starting first question...');
-    gameQuestions.moveToNextQuestion();
+    hasStartedFirstQuestion.value = true;
     playNextQuestion();
   };
 
@@ -259,7 +271,7 @@ export function useGameCore(gameConfig) {
   });
 
   return {
-    numOfAudiosPlayed: gameQuestions.currentQuestionIndex,
+    numOfAudiosPlayed,
     score,
     isRecording,
     isFinalResult,

--- a/src/composables/useGameUI.js
+++ b/src/composables/useGameUI.js
@@ -20,7 +20,11 @@ export function useGameUI(gameState) {
         : 'w-[250px] h-[116px]',
     gameState.isRecording.value ? 'bg-red-500' : 'bg-[#087BB4]',
     'text-white',
-    isButtonDisabled.value ? 'opacity-50 cursor-not-allowed' : '',
+    isButtonDisabled.value
+      ? 'opacity-50 cursor-not-allowed'
+      : gameState.isRecording.value
+        ? 'hover:bg-red-700'
+        : 'hover:bg-[#0C587D]',
   ]);
 
   const recordButtonTitle = computed(() => {

--- a/src/pages/Footer/GamePagesFooter.vue
+++ b/src/pages/Footer/GamePagesFooter.vue
@@ -1,13 +1,13 @@
 <!-- GamePagesFooter.vue -->
 <template>
   <footer
-    class="absolute bottom-1/2 right-[-113px] z-50 rotate-[-90deg] flex items-center justify-between ml-auto bg-cross-lines md-shadow"
+    class="absolute bottom-1/2 right-[-113px] z-50 rotate-[-90deg] flex items-center justify-between ml-auto bg-cross-lines shadow-md"
   >
     <!-- Something Not Working? Button -->
     <div class="whitespace-nowrap">
       <button
         @click="handleSthNotWorkingButtonClick"
-        class="text-[16px] text-black font-semibold py-2 px-4 rounded-lg flex items-center gap-2"
+        class="text-[15px] hover:text-[16px] ease-in duration-300 text-black font-semibold py-2 px-4 rounded-lg flex items-center gap-2"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/GameZone/GameZoneList/AdditionGame.vue
+++ b/src/pages/GameZone/GameZoneList/AdditionGame.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.addition;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/AskingForAssistance.vue
+++ b/src/pages/GameZone/GameZoneList/AskingForAssistance.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.askingForAssistance;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/BusStopBrainstorm.vue
+++ b/src/pages/GameZone/GameZoneList/BusStopBrainstorm.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.busStopBrainstorm;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/CaneCompanion.vue
+++ b/src/pages/GameZone/GameZoneList/CaneCompanion.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.caneCompanion;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/CarCounting.vue
+++ b/src/pages/GameZone/GameZoneList/CarCounting.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="getCurrentAnswer()"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -24,22 +29,18 @@
       <PlayButton v-if="playButton === false" @play-click="playButton = true" />
 
       <div
-        v-else-if="hasQuestionsRemaining && playButton === true"
+        v-else-if="numOfAudiosPlayed < 5 && playButton === true"
         class="flex flex-col p-4 justify-center"
         id="content"
       >
         <StartQuestionsButton
-          v-show="
-            (isTablet || isMobile) &&
-            currentQuestionIndex === 0 &&
-            !isIntroPlaying
-          "
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="!(isTablet || isMobile) || !isIntroPlaying"
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -114,13 +115,13 @@ const {
   isGameComplete,
 } = carCounting;
 
-const numOfAudiosPlayed = currentQuestionIndex;
 const score = ref(0);
 const isRecording = ref(false);
 const isFinalResult = ref(false);
 const transcription = ref('');
 const isAnswerPlaying = ref(false);
 const isCorrect = ref(false);
+const hasStartedFirstQuestion = ref(false);
 
 // UI control states
 const playButton = ref(false);
@@ -145,6 +146,13 @@ const { goBack, handleSthNotWorkingButtonClick } = useGameNavigation(
 );
 
 // 4. Computed Properties
+const numOfAudiosPlayed = computed(() => {
+  if (hasStartedFirstQuestion.value && currentQuestionIndex.value === 0) {
+    return 1;
+  }
+  return currentQuestionIndex.value;
+});
+
 const isButtonDisabled = computed(
   () => gameUI.isButtonDisabled.value || isPlaying.value
 );
@@ -181,10 +189,6 @@ onMounted(() => {
       currentAudios.push(introAudio);
       introAudio.onended = () => {
         isIntroPlaying.value = false;
-        // Only auto-play next question on desktop
-        if (isDesktop.value) {
-          playNextQuestion();
-        }
       };
     }
   });
@@ -339,8 +343,11 @@ const repeatQuestion = () => {
  */
 const startFirstQuestion = () => {
   console.log('Starting first question...');
+  hasStartedFirstQuestion.value = true;
+
+  // Remain at current index 0
+  // since toggleRecording() calls moveToNextQuestion()
   playNextQuestion();
-  moveToNextQuestion();
 };
 
 // 8. Exposed Values

--- a/src/pages/GameZone/GameZoneList/CleanMachine.vue
+++ b/src/pages/GameZone/GameZoneList/CleanMachine.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.cleanMachine;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/ColorGame.vue
+++ b/src/pages/GameZone/GameZoneList/ColorGame.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.colorGame;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.definitionDetective;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
+++ b/src/pages/GameZone/GameZoneList/DefinitionDetective.vue
@@ -23,6 +23,7 @@
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
+        :firstMatchingAnswer="firstMatchingAnswer"
       />
 
       <PlayButton v-if="playButton === false" @play-click="playButton = true" />
@@ -87,6 +88,7 @@ const {
   isButtonCooldown,
   isAnswerPlaying,
   isCorrect,
+  firstMatchingAnswer,
   isTablet,
   isMobile,
   isDesktop,

--- a/src/pages/GameZone/GameZoneList/DinoDetectives.vue
+++ b/src/pages/GameZone/GameZoneList/DinoDetectives.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.dinoDetectives;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/DivisionDuel.vue
+++ b/src/pages/GameZone/GameZoneList/DivisionDuel.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.division;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/DoorwayDecisions.vue
+++ b/src/pages/GameZone/GameZoneList/DoorwayDecisions.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.doorwayDecisions;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/DressToImpress.vue
+++ b/src/pages/GameZone/GameZoneList/DressToImpress.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.dressToImpress;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/EcoRangers.vue
+++ b/src/pages/GameZone/GameZoneList/EcoRangers.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.ecoRangers;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/ElevatorExperience.vue
+++ b/src/pages/GameZone/GameZoneList/ElevatorExperience.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.elevatorExperience;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
+++ b/src/pages/GameZone/GameZoneList/FruitFrenzy.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.fruitFrenzy;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/GermSquad.vue
+++ b/src/pages/GameZone/GameZoneList/GermSquad.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.germSquad;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/GroceryGrab.vue
+++ b/src/pages/GameZone/GameZoneList/GroceryGrab.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.groceryGrab;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/HealthCheck.vue
+++ b/src/pages/GameZone/GameZoneList/HealthCheck.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.healthCheck;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/HealthyPlate.vue
+++ b/src/pages/GameZone/GameZoneList/HealthyPlate.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.healthyPlate;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/KitchenCues.vue
+++ b/src/pages/GameZone/GameZoneList/KitchenCues.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.kitchenCues;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/KitchenKnowHow.vue
+++ b/src/pages/GameZone/GameZoneList/KitchenKnowHow.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.kitchenKnowHow;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/KitchenTimerTrouble.vue
+++ b/src/pages/GameZone/GameZoneList/KitchenTimerTrouble.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.kitchenTimerTrouble;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/LaundryLegend.vue
+++ b/src/pages/GameZone/GameZoneList/LaundryLegend.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.laundryLegend;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/MatterMixUp.vue
+++ b/src/pages/GameZone/GameZoneList/MatterMixUp.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.matterMixUp;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/MedicationManager.vue
+++ b/src/pages/GameZone/GameZoneList/MedicationManager.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.medicationManager;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/MoneyManager.vue
+++ b/src/pages/GameZone/GameZoneList/MoneyManager.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.moneyManager;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/MoneyMatch.vue
+++ b/src/pages/GameZone/GameZoneList/MoneyMatch.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.moneyMatch;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/MoneyMatters.vue
+++ b/src/pages/GameZone/GameZoneList/MoneyMatters.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.moneyMatters;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MonkeyMadness.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.monkeyMadness;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
+++ b/src/pages/GameZone/GameZoneList/MultiplicationMadness.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.multiplication;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/ObstacleAwareness.vue
+++ b/src/pages/GameZone/GameZoneList/ObstacleAwareness.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.obstacleAwareness;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/OddOneOut.vue
+++ b/src/pages/GameZone/GameZoneList/OddOneOut.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.oddOneOut;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
+++ b/src/pages/GameZone/GameZoneList/PartOfSpeech.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.partOfSpeech;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/PhoneFriend.vue
+++ b/src/pages/GameZone/GameZoneList/PhoneFriend.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.phoneFriend;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/PlantPower.vue
+++ b/src/pages/GameZone/GameZoneList/PlantPower.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.plantPower;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/PolarPairing.vue
+++ b/src/pages/GameZone/GameZoneList/PolarPairing.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.polarPairing;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/RobotRepair.vue
+++ b/src/pages/GameZone/GameZoneList/RobotRepair.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.robotRepair;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/SafetySirens.vue
+++ b/src/pages/GameZone/GameZoneList/SafetySirens.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.safetySirens;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/ScheduleShuffle.vue
+++ b/src/pages/GameZone/GameZoneList/ScheduleShuffle.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.scheduleShuffle;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/ShapeShark.vue
+++ b/src/pages/GameZone/GameZoneList/ShapeShark.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.shapeShark;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/SocialSense.vue
+++ b/src/pages/GameZone/GameZoneList/SocialSense.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.socialSense;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/SoundExplorer.vue
+++ b/src/pages/GameZone/GameZoneList/SoundExplorer.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.soundExplorer;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/SpaceCase.vue
+++ b/src/pages/GameZone/GameZoneList/SpaceCase.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.spaceCase;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/SpellingBee.vue
+++ b/src/pages/GameZone/GameZoneList/SpellingBee.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.spellingBee;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/StreetSmart.vue
+++ b/src/pages/GameZone/GameZoneList/StreetSmart.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.streetSmart;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/SubtractionGame.vue
+++ b/src/pages/GameZone/GameZoneList/SubtractionGame.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -29,16 +34,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -76,6 +78,7 @@ const gameConfig = gameConfigs.subtraction;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.syllableSorting;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/SyllableSorting.vue
+++ b/src/pages/GameZone/GameZoneList/SyllableSorting.vue
@@ -23,6 +23,7 @@
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
+        :firstMatchingAnswer="firstMatchingAnswer"
       />
 
       <PlayButton v-if="playButton === false" @play-click="playButton = true" />
@@ -87,6 +88,7 @@ const {
   isButtonCooldown,
   isAnswerPlaying,
   isCorrect,
+  firstMatchingAnswer,
   isTablet,
   isMobile,
   isDesktop,

--- a/src/pages/GameZone/GameZoneList/TimeTamer.vue
+++ b/src/pages/GameZone/GameZoneList/TimeTamer.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.timeTamer;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/TinyCellTown.vue
+++ b/src/pages/GameZone/GameZoneList/TinyCellTown.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.tinyCellTown;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/TransitTime.vue
+++ b/src/pages/GameZone/GameZoneList/TransitTime.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.transitTime;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/Vocab.vue
+++ b/src/pages/GameZone/GameZoneList/Vocab.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.vocab;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,

--- a/src/pages/GameZone/GameZoneList/WeatherWhiz.vue
+++ b/src/pages/GameZone/GameZoneList/WeatherWhiz.vue
@@ -13,8 +13,13 @@
         :title="gameConfig.title"
         :description="gameConfig.description"
         :isMobile="isMobile"
-        :showCaptions="playButton && !isIntroPlaying && numOfAudiosPlayed < 5"
-        :numOfAudiosPlayed="numOfAudiosPlayed"
+        :showCaptions="
+          playButton &&
+          !isIntroPlaying &&
+          numOfAudiosPlayed > 0 &&
+          numOfAudiosPlayed < 5
+        "
+        :currentQuestionIndex="currentQuestionIndex"
         :currentQuestion="currentQuestion"
         :isAnswerPlaying="isAnswerPlaying"
         :isCorrect="isCorrect"
@@ -28,16 +33,13 @@
         id="content"
       >
         <StartQuestionsButton
-          v-show="(isTablet || isMobile) && numOfAudiosPlayed === 0"
+          v-show="numOfAudiosPlayed === 0"
           :isIntroPlaying="isIntroPlaying"
           @start-click="startFirstQuestion"
         />
 
         <GameControls
-          v-show="
-            !(isTablet || isMobile) ||
-            (!isIntroPlaying && numOfAudiosPlayed > 0)
-          "
+          v-show="!isIntroPlaying && numOfAudiosPlayed > 0"
           :isTablet="isTablet"
           :isMobile="isMobile"
           :isRecording="isRecording"
@@ -75,6 +77,7 @@ const gameConfig = gameConfigs.weatherWhiz;
 
 const {
   numOfAudiosPlayed,
+  currentQuestionIndex,
   score,
   isRecording,
   isFinalResult,


### PR DESCRIPTION
# References
- Follow-up to PR [#268](https://github.com/Crustaly/audemywebsite/pull/268)
- Fixes [#276](https://github.com/Crustaly/audemywebsite/issues/276)
- Fixes [#269](https://github.com/Crustaly/audemywebsite/issues/269)

> [!NOTE]
> This PR uses and builds upon logic by @DooHwanKim0419 (thanks!)

---

# Summary

## 1. Fix: 1st Question UI Timing on Mobile & Tablet Views
- Fix UI/logical bug where:
  - Captions for 1st Qn & progress bar UI appeared too early
  - & Game would incorrectly skip to the 2nd Qn after <kbd>"Start Q's" </kbd>

## 2. Fix/Feat: Add <kbd>"Start Questions"</kbd> Button/Logic on Desktop
- Add <kbd>"Start Questions"</kbd> button/logic for desktop users after the intro audio completes
- Fix/align logic for `currentQuestionIndex` across all devices
- Remove all device-based UI rendering & auto-play logic for simpler code maintenance
- Improve UI consistency & UX by allowing desktop users to start Q's when ready

## 3. Refactor: `<GameHeader/>` → UI Components
- Refactor `<GameHeader/>` into components:
  - `<GameProgressBar/>`
  - `<QuestionCaptions/>`
  - `<AnswerCaptions/>`:
    - Improve template clarity with new `captionText` computed property (vs complex, inline conditionals)
- Extract complex UI classes into `GameHeaderConstants.js` for readability

---

# Minor Updates
<details>
  <summary>1. <b>Feat:</b> Add conditional hover effects to game buttons</summary>

- Affected buttons: <kbd>Go Back</kbd>, <kbd>Something Not Working?</kbd>, <kbd>Play</kbd>, <kbd>Start Q's</kbd>, <kbd>Record/Stop</kbd>, and <kbd>Repeat</kbd>

</details>

<details>
  <summary>2. <b>Fix:</b> Add digit-based answers to "Syllable Sorting"</summary>

- Add digit-based numbers to `syllableGameDB.json`
- Pass `firstMatchingAnswer` to `<GameHeader/>` to align UI captions
  
</details>

<details>
  <summary>3. <b>Fix:</b> Align UI captions for "Definition Detective" synonymous answers</summary>

- Fix UI caption/transcript alignment for synonyms via `firstMatchingAnswer` prop
  
</details>

<details>
  <summary>4. <b>Cleanup:</b> <code>definitionDetectiveDb.json</code> answers</summary>

- Remove misleading homophones in game answers to improve transcription validation & answer clarity
- Ex: **"ball"** vs "bawl"; **"teacher"** vs "teach her"

</details>

---

# Screenshots

### Fix: UI Timing for 1st Qn's on Mobile & Tablet

<details>
  <summary>View Mobile Fix</summary>

| Before: Mobile <br>(Early / Skipped 1st Qn) | After: Mobile Fix <br>(Timed UI) |  After: Mobile Fix <br>(1st Qn is not skipped) |
| :---:  | :--: | :--: |
| <img src="https://github.com/user-attachments/assets/ac48d34c-9ff7-440b-9ab2-ffa0c9916248" width="300" /> | <img src="https://github.com/user-attachments/assets/de8e93b4-3b0c-4b68-8639-6dc98784191e" width="300" /> |<img src="https://github.com/user-attachments/assets/87bbba0e-7b97-4604-bee9-26ec8d419962" width="300" /> |

</details>

<details>
  <summary>View Tablet Fix</summary>
  
| Before: Tablet <br>(Early / Skipped 1st Qn) | After: Tablet Fix <br>(Timed UI) | After: Tablet Fix <br>(1st Qn is not skipped) | 
| :---:  | :--: | :--: |
| <img src="https://github.com/user-attachments/assets/205e65ae-6899-444d-b268-010a3e647982" width="400" /> | <img src="https://github.com/user-attachments/assets/d3e4583d-4be8-4a8e-82db-ed2004faacb0" width="400" /> | <img src="https://github.com/user-attachments/assets/314234b9-f214-4d02-907b-750537983fae" width="400" /> |

</details>

---

### Fix/Feat: Add <kbd>"Start Questions"</kbd> on Desktop to Align Current Qn Index

<details>
  <summary>View Desktop</summary>

| Updated Desktop UI <br> (+ Start Q's button) | Desktop 1st Qn <br> (For reference; no changes) |
| :---:  | :---: | 
| <img src="https://github.com/user-attachments/assets/c9162505-e881-4070-8d32-8fdd29ac196a" width="500" /> | <img src="https://github.com/user-attachments/assets/db5568d2-fe5d-4897-94f6-3beee74029df" width="500" />  |

</details>

---

### Fix: Add Digit-based Numbers to "Syllable Sorting"

<details>
  <summary>View</summary>

| Digit-based # | Word-based # |
| :---:  |  :---:  | 
| <img src="https://github.com/user-attachments/assets/0a558599-fbf6-4458-80c5-8da943151b0b" width="500" /> | <img src="https://github.com/user-attachments/assets/d05bea2b-df41-48d6-91e8-929c526c5176" width="500" /> |

</details>

---

# Manual Tests

<details><summary>View</summary>

- Tested game functionality across all games
- Tested mobile (eg. `350px`), tablet, and desktop (eg. `1680px`) views for captions timing
- Tested <kbd>"Start Q's"</kbd> button now appears and is functional on desktop (aka all devices) after intro audio completes
- Tested UI captions/transcript alignment for **"Definition Detective"**
- Tested both digit- and word-based numbers for **"Syllable Sorting"**
- Tested timed hover effects for game buttons
   
</details>