### PR TITLE
fix: Keyboard accessibility in "Home" video

### DIFF
--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -5,31 +5,17 @@ import OrangeStar from '/assets/images/impact/orangeStar.png';
 import Headphones from '/assets/images/techShowcase/headphone.png';
 import Mic from '/assets/images/techShowcase/microphone.png';
 
+import { useDeviceDetection } from '../../../composables/useDeviceDetection';
+
 import { ref, onMounted, onUnmounted } from 'vue';
 
 let isplaying = ref(false);
 let video = ref();
-const isTablet = ref(false);
-const isMobile = ref(false);
 const videoVisible = ref(false);
 
 // Check device type
-const checkDeviceType = () => {
-  const width = window.innerWidth;
-  if (width >= 640 && width < 768) {
-    isTablet.value = false;
-    isMobile.value = true;
-  } else if (width >= 768 && width < 1024) {
-    isTablet.value = true;
-    isMobile.value = false;
-  } else if (width >= 1024) {
-    isTablet.value = false;
-    isMobile.value = false;
-  } else {
-    isTablet.value = false;
-    isMobile.value = true;
-  }
-};
+// NOTE: Current UI logic only uses 'isTablet' flag
+const { isTablet } = useDeviceDetection();
 
 let observer;
 
@@ -42,9 +28,6 @@ const onVideoIntersect = (entries) => {
 };
 
 onMounted(() => {
-  checkDeviceType();
-  window.addEventListener('resize', checkDeviceType);
-
   observer = new IntersectionObserver(onVideoIntersect, {
     root: null,
     threshold: 0.3,
@@ -55,7 +38,6 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  window.removeEventListener('resize', checkDeviceType);
   if (observer) observer.disconnect();
 });
 

--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -12,6 +12,7 @@ import { ref, onMounted, onUnmounted } from 'vue';
 let isplaying = ref(false);
 let video = ref();
 const videoVisible = ref(false);
+let showTooltipMsg = ref(false);
 
 // Check device type
 // NOTE: Current UI logic only uses 'isTablet' flag
@@ -132,9 +133,28 @@ const exitVideoControls = () => {
           - Remove noisy, unhelpful SR output with 'role'
         -->
 
+        <!-- Visual 'tooltip' of video shortcuts (for sighted keyboard users)
+          - Text visibility based on video focus state
+          - Hidden from SR output since ARIA label already announces it
+          - NOTE: SR output repeats 'title' attribute, so this is a workaround
+        -->
+        <div
+          class="text-center my-2 flex flex-col items-center"
+          aria-hidden="true"
+          v-show="showTooltipMsg"
+        >
+          <p class="text-sm">
+            <b>Key shortcuts:</b> Press
+            <span class="font-semibold">Space</span> to toggle video &
+            <span class="font-semibold">Esc</span> to exit.
+          </p>
+        </div>
+
         <button
           tabindex="0"
           id="lazy-video-wrapper"
+          @focus="showTooltipMsg = true"
+          @blur="showTooltipMsg = false"
           @keyup.space.prevent="toggleVideo"
           @keyup.esc.prevent="exitVideoControls"
           aria-label="Press 'Space' to play or pause video. Press 'Escape' to exit video controls."

--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -59,12 +59,23 @@ let videoStoped = () => {
   pauseVideo();
   video.value.removeAttribute('controls', '');
 };
+
+// WCAG: Prevent focus trap in video controls after interaction
+const exitVideoControls = () => {
+  if (isplaying.value) {
+    pauseVideo();
+  }
+  // Manually move focus to 'Discover more' button
+  const nextFocusTarget = document.getElementById('discoverMoreBtn');
+  nextFocusTarget.focus();
+};
 </script>
 
 <template>
   <div
     class="lg:relative flex items-center flex-col lg:flex-row justify-center items-center gap-x-5 gap-y-16 md:gap-y-0 py-10 my-10"
     :class="{ 'tablet-showcase': isTablet }"
+    role="none"
   >
     <!-- Decorative icons (medium+ screens) -->
     <PageDecorations
@@ -90,18 +101,35 @@ let videoStoped = () => {
     -->
     <div
       class="w-full md:w-2/5 flex flex-col md:flex-row justify-center items-center"
+      role="none"
     >
       <div
         class="relative w-[295px] h-[529px] tablet:w-[238px] tablet:h-[426px] mobile:w-[296px] mobile:h-[529px] mobile:order-2"
+        role="none"
       >
         <!-- Decorative phone overlay -->
         <img
           class="w-[295px] h-[529px] tablet:w-[238px] tablet:h-[426px] mobile:w-[296px] mobile:h-[529px] max-w-none"
           src="/assets/images/techShowcase/phone.svg"
-          alt=""
+          aria-hidden="true"
         />
-        <div
+
+        <!-- Lazy Video Wrapper Button 
+          - WCAG (Keyboard Access.): Video is in tab order & avoids focus trap in video controls
+          - Tab: Focus video
+          - Enter: Play 
+          - Space: Pause 
+          - Esc: Pause, exit, & go to next focus target ('Discover more' button) 
+          - Remove noisy, unhelpful SR output with 'role'
+        -->
+
+        <button
+          tabindex="0"
           id="lazy-video-wrapper"
+          @keyup.enter="playVideo"
+          @keyup.space.prevent="pauseVideo"
+          @keyup.esc.prevent="exitVideoControls"
+          aria-label="Press 'Enter' to play video. Press 'Space' to pause. Press 'Escape' to exit video controls."
           class="absolute w-[88%] left-[6%] h-[82%] top-[9%] mx-auto z-0 overflow-hidden rounded-[16px]"
         >
           <!-- Poster image -->
@@ -111,16 +139,19 @@ let videoStoped = () => {
             style="
               background-image: url('/assets/images/techShowcase/video-poster.png');
             "
+            aria-hidden="true"
           ></div>
 
-          <!-- Play Button -->
+          <!-- WCAG: Hide decorative orange play button -->
           <div
             v-if="!isplaying"
             @click="playVideo"
             ref="playBut"
             class="absolute z-10 cursor-pointer w-[56px] h-[56px] rounded-[50%] border-[2px] border-[black] bg-[#FE892A] hover:bg-[#D6711F] top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]"
+            aria-hidden="true"
           >
             <div
+              aria-hidden="true"
               class="tra absolute w-[22px] h-[22px] top-[50%] left-[50%] translate-x-[-40%] bg-black translate-y-[-50%] rotate-90"
             ></div>
           </div>
@@ -142,7 +173,7 @@ let videoStoped = () => {
             />
             <span>browser does not support the video tag.</span>
           </video>
-        </div>
+        </button>
       </div>
     </div>
 
@@ -170,6 +201,7 @@ let videoStoped = () => {
 
         <div class="page-button-flex">
           <a
+            id="discoverMoreBtn"
             href="our-projects"
             class="page-button blue-button px-9 mobile:h-auto py-3 md:w-[300px]"
           >

--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -9,7 +9,7 @@ import { useDeviceDetection } from '../../../composables/useDeviceDetection';
 
 import { ref, onMounted, onUnmounted } from 'vue';
 
-let isplaying = ref(false);
+let isPlaying = ref(false);
 let video = ref();
 const videoVisible = ref(false);
 let showTooltipMsg = ref(false);
@@ -45,7 +45,7 @@ onUnmounted(() => {
 // toggleVideo(): Handles 'Space' key shortcut to play or pause video
 // Supports WCAG Keyboard Accessibility
 const toggleVideo = () => {
-  if (!isplaying.value) {
+  if (!isPlaying.value) {
     playVideo();
   } else {
     pauseVideo();
@@ -53,27 +53,27 @@ const toggleVideo = () => {
 };
 
 const playVideo = () => {
-  if (!isplaying.value) {
-    isplaying.value = true;
+  if (!isPlaying.value) {
+    isPlaying.value = true;
     video.value.setAttribute('controls', '');
     video.value.play();
   }
 };
 
 let pauseVideo = () => {
-  isplaying.value = false;
+  isPlaying.value = false;
   video.value.pause();
 };
 
 let videoStoped = () => {
-  isplaying.value = false;
+  isPlaying.value = false;
   pauseVideo();
   video.value.removeAttribute('controls', '');
 };
 
 // WCAG: Prevent focus trap in video controls after interaction
 const exitVideoControls = () => {
-  if (isplaying.value) {
+  if (isPlaying.value) {
     pauseVideo();
   }
   // Manually move focus to 'Discover more' button
@@ -162,7 +162,7 @@ const exitVideoControls = () => {
         >
           <!-- Poster image -->
           <div
-            v-if="!isplaying"
+            v-if="!isPlaying"
             class="w-full h-full bg-cover bg-center"
             style="
               background-image: url('/assets/images/techShowcase/video-poster.png');
@@ -172,7 +172,7 @@ const exitVideoControls = () => {
 
           <!-- WCAG: Hide decorative orange play button -->
           <div
-            v-if="!isplaying"
+            v-if="!isPlaying"
             @click="playVideo"
             ref="playBut"
             class="absolute z-10 cursor-pointer w-[56px] h-[56px] rounded-[50%] border-[2px] border-[black] bg-[#FE892A] hover:bg-[#D6711F] top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]"

--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -41,6 +41,16 @@ onUnmounted(() => {
   if (observer) observer.disconnect();
 });
 
+// toggleVideo(): Handles 'Space' key shortcut to play or pause video
+// Supports WCAG Keyboard Accessibility
+const toggleVideo = () => {
+  if (!isplaying.value) {
+    playVideo();
+  } else {
+    pauseVideo();
+  }
+};
+
 const playVideo = () => {
   if (!isplaying.value) {
     isplaying.value = true;
@@ -117,8 +127,7 @@ const exitVideoControls = () => {
         <!-- Lazy Video Wrapper Button 
           - WCAG (Keyboard Access.): Video is in tab order & avoids focus trap in video controls
           - Tab: Focus video
-          - Enter: Play 
-          - Space: Pause 
+          - Space: Play or Pause (via toggleVideo)
           - Esc: Pause, exit, & go to next focus target ('Discover more' button) 
           - Remove noisy, unhelpful SR output with 'role'
         -->
@@ -126,10 +135,9 @@ const exitVideoControls = () => {
         <button
           tabindex="0"
           id="lazy-video-wrapper"
-          @keyup.enter="playVideo"
-          @keyup.space.prevent="pauseVideo"
+          @keyup.space.prevent="toggleVideo"
           @keyup.esc.prevent="exitVideoControls"
-          aria-label="Press 'Enter' to play video. Press 'Space' to pause. Press 'Escape' to exit video controls."
+          aria-label="Press 'Space' to play or pause video. Press 'Escape' to exit video controls."
           class="absolute w-[88%] left-[6%] h-[82%] top-[9%] mx-auto z-0 overflow-hidden rounded-[16px]"
         >
           <!-- Poster image -->

--- a/src/pages/Impact/PressList/PressList.vue
+++ b/src/pages/Impact/PressList/PressList.vue
@@ -219,13 +219,13 @@ onUnmounted(() => {
       <div class="w-full py-5 md:my-10">
         <!-- Header -->
         <div>
-          <h3 class="page-header-accent">PRESS LIST</h3>
+          <h2 class="page-header-accent">PRESS LIST</h2>
         </div>
         <div>
-          <h2 class="page-header">
+          <h3 class="page-header">
             Trusted by
             <em class="text-secondary-color"> Leading Publications </em>
-          </h2>
+          </h3>
         </div>
       </div>
       <!-- Responsive Grid Layout: 1 Column (Mobile); 2 Cols (Small); 3 Cols (Medium); 4 Cols (Large) -->

--- a/src/pages/Impact/PressList/PressList.vue
+++ b/src/pages/Impact/PressList/PressList.vue
@@ -11,7 +11,7 @@ const items = [
   },
   {
     image: 'white-house-resized-icon.png',
-    text: 'Audemy Featured as Major Organization Commit to Supporting AI Education',
+    text: 'Audemy Featured as Major Organization Committed to Supporting AI Education',
     network: 'The White House',
     url: 'https://www.whitehouse.gov/articles/2025/09/major-organizations-commit-to-supporting-ai-education/',
   },

--- a/src/pages/Impact/PressList/PressListCard.vue
+++ b/src/pages/Impact/PressList/PressListCard.vue
@@ -2,7 +2,6 @@
 const props = defineProps({
   image: String,
   text: String,
-  author: String,
   network: String,
   url: String,
 });
@@ -13,14 +12,14 @@ const path = '/assets/images/impact/';
   <div class="w-full mx-auto flex flex-row justify-center h-auto">
     <div class="w-full max-w-[360px] px-4">
       <div
-        class="flex flex-col items-center justify-evenly h-auto rounded-[8px] gap-4 mobile:px-4"
+        class="font-poppins flex flex-col items-center justify-evenly h-auto rounded-[8px] gap-4 mobile:px-4"
       >
         <!-- NEWS NETWORK (HEADING) -->
         <div
-          class="w-full flex items-center justify-center h-[60px] text-center px-2"
+          class="w-full flex items-center justify-center h-[80px] text-center"
         >
           <h2
-            class="text-[26px] font-bold font-poppins tablet:text-[14px] font-[600] mobile:text-[14px]"
+            class="text-[16px] md:text-[18px] xl:text-[20px] font-bold"
             v-html="network"
           ></h2>
         </div>
@@ -54,18 +53,10 @@ const path = '/assets/images/impact/';
             class="block"
           >
             <h3
-              class="text-gray-500 font-poppins font-[600] text-[16px] tablet:text-[14px] mobile:text-[14px] hover:text-blue-600 transition-colors duration-200 cursor-pointer"
+              class="text-gray-500 font-[600] text-[16px] tablet:text-[14px] mobile:text-[14px] hover:text-blue-600 transition-colors duration-200 cursor-pointer"
               v-html="text"
             ></h3>
           </a>
-        </div>
-
-        <!-- AUTHOR -->
-        <div class="w-full text-right mobile:text-center px-2">
-          <p
-            class="text-body-text-color font-poppins text-[14px] tablet:text-[10px] font-[500] mobile:text-[12px]"
-            v-html="author"
-          ></p>
         </div>
       </div>
     </div>

--- a/src/pages/Impact/PressList/PressListCard.vue
+++ b/src/pages/Impact/PressList/PressListCard.vue
@@ -25,8 +25,11 @@ const path = '/assets/images/impact/';
           ></h2>
         </div>
 
-        <!-- IMAGE -->
-        <div class="w-full flex justify-center">
+        <!-- CLICKABLE IMAGE 
+          - SR Accessibility: Remove linked images from tab order to remove redundant output 
+          - Text link remains tabbable
+        -->
+        <div class="w-full flex justify-center" aria-hidden="true">
           <a
             :href="url"
             target="_blank"
@@ -50,10 +53,10 @@ const path = '/assets/images/impact/';
             rel="noopener noreferrer"
             class="block"
           >
-            <h4
+            <h3
               class="text-gray-500 font-poppins font-[600] text-[16px] tablet:text-[14px] mobile:text-[14px] hover:text-blue-600 transition-colors duration-200 cursor-pointer"
               v-html="text"
-            ></h4>
+            ></h3>
           </a>
         </div>
 


### PR DESCRIPTION
## $\color{Emerald}{Before: \ Accessibility \ Issues}$

### 1. Home Page: Keyboard-Inaccessible Video

<details>
<summary>details</summary>

* "Home" Video is not in tab order → Not keyboard accessible
* Video accessible only via manual mouse click
* Violates [WCAG Success Criteria 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html) (Keyboard Access.)

</details>

---

## $\color{Emerald}{After: \ WCAG \ Fixes}$

### 1. Keyboard Accessible Video

<details>
<summary>details</summary>

* **SR & keyboard users:**  Added custom key shortcuts
  - **Focus video:** <kbd>Tab</kbd>
  - **Play or Pause video (toggle):** <kbd>Space</kbd>
  - **Pause, exit, & move to next focus ('Discover more' button)**: <kbd>Esc</kbd>
      - This shortcut avoids a focus trap in video controls
* **Sighted Keyboard Users:** Custom 'Tooltip' of key shortcuts
    - UI visibility based on video's focus state
    - Hidden for mouse-only users & hidden once focus leaves video 

**NOTE:**
> - SR output repeats info when using ARIA label and native `title`
> - Custom tooltip = Workaround to improve UI clarity for sighted keyboard users

</details>

---

### 2. Minor Fixes & Refactor

<details>
<summary>details</summary>

* Fix: Skipped headers for SR-accessible semantics
* Refactor `TechShowcase.vue`: Replace device-check logic & import existing `useDeviceDetection.js` 
* Minor Fix: Grammar in "White House" Press List card

</details>

---

## $\color{Emerald}{Previews}$

### Fix: Keyboard Accessible Video

#### Screenshots
<details>
 <summary>View</summary>

| Tooltip + SR Output <br> (Video = focused; blue ring) |
| :---: |
| <img width="600" alt="Screenshot 2025-10-09 at 5 24 57 PM" src="https://github.com/user-attachments/assets/b3a1dd80-7687-4134-a945-6ea5b345cbf2" /> |

| Hidden Tooltip <br> ("Discover More" btn = focused) |
| :---: |
| <img width="600" alt="focus based tooltip hidden" src="https://github.com/user-attachments/assets/c6bf5157-1854-4432-890c-c098e69ce662" /> |

</details>

---

#### Live VoiceOver Demo
<details>
 <summary>View</summary>

| SR Output |
| :---: |
| <video src="https://github.com/user-attachments/assets/a0b059a5-0dd8-402b-abe5-ccd060a15d1e" width="500" />|

</details>

---

### Minor Fix: Press List Card

<details>
 <summary>View</summary>

| Before | After |
| :---: | :---: |
| <img width="200" alt="before" src="https://github.com/user-attachments/assets/6212d405-648a-48f6-ac08-3553f946aeb1" /> | <img width="200" alt="after" src="https://github.com/user-attachments/assets/50372d3d-287d-4486-b011-51b82efbd643" /> |

</details>

---

## $\color{Emerald}{Manual \ Tests}$

- Checked SR / VoiceOver Output
- Lighthouse Accessibility Score for "Home" Page: 90 → 96 (Remaining Issue: low contrast)
- Tested cases below (Checklist provided for clarity/PR review)

<details>
 <summary>View checklist</summary>

**Home Video Keyboard Interaction:**
- [ ] **1. Focus & Tooltip:** <kbd>Tab</kbd> thru "Home" Page, reaching the last "What We Do" link. Then press <kbd>Tab</kbd> again → **Expect:** Video gains focus (blue ring) & custom tooltip appears. 

- [ ] **2. Play/Pause:** Press <kbd>Space</kbd> → **Expect:** Video toggles b/t Play & Pause.

- [ ] **3. WCAG Exit Fix:** Press <kbd>Esc</kbd> once → **Expect:** Video pauses, focus moves to the next target (<kbd>"Discover more"</kbd>), & tooltip disappears. 

- [ ] **4. Video Controls Focus Trap (Comparison Test):** <kbd>Tab</kbd> thru "Home" Page to reach & focus video. <kbd>Tab</kbd> again to focus native video controls → **Expect:** Focus trap (Avoided thru **# 3 above**)

</details>

> **Environment Note:**
>    - **Mac Touchbar/VoiceOver Users:** If using a Mac with a Touchbar, VoiceOver may require double-tapping <kbd>Esc</kbd> to exit video focus (due to native OS behavior)
>    - **Non-SR Users:** Single tap <kbd>Esc</kbd> (regardless of Touchbar)
