### PR TITLE
fix: Inefficient Tab Stops in "Team" Pg. (Keyboard Access.)

### DIFF
--- a/src/pages/AboutUs/AboutUs.vue
+++ b/src/pages/AboutUs/AboutUs.vue
@@ -5,23 +5,12 @@ import ScrollUpButton from '../../components/ScrollUpButton/ScrollUpButton.vue';
 import CarlsJourney from './CarlsJourney/CarlsJourney.vue';
 import Volunteers from './Volunteers/Volunteers.vue';
 import TopDecoration from './TopDecoration/TopDecoration.vue';
-
-import { useDeviceType } from '../../Utilities/checkDeviceType';
-const { isMobile, isTablet } = useDeviceType();
 </script>
 
 <template>
   <ScrollUpButton />
 
-  <div
-    :class="[
-      'relative',
-      !isTablet && !isMobile ? 'px-14' : '',
-      isTablet ? 'px-6' : '',
-      isMobile ? 'px-8' : '',
-    ]"
-    ref="content"
-  >
+  <div class="relative px-8 sm:px-8 md:px-6 lg:px-14 font-poppins">
     <Header :logoPath="'/assets/images/header/header-logo-2.png'" />
     <TopDecoration />
     <Volunteers />

--- a/src/pages/AboutUs/Volunteers/Volunteers.vue
+++ b/src/pages/AboutUs/Volunteers/Volunteers.vue
@@ -11,7 +11,7 @@ onMounted(() => {
 
 <template>
   <div class="font-poppins flex justify-center mb-10">
-    <div class="w-full h-auto">
+    <div class="w-full h-auto relative">
       <!-- Section Header -->
       <div class="w-full">
         <h3 class="page-header-accent">OUR TEAM</h3>
@@ -26,11 +26,11 @@ onMounted(() => {
         - Bypass 80+ social media links
         - Link offers quick jump to next section ('Join our Team')
       -->
-      <div class="page-button-flex relative">
+      <div class="page-button-flex">
         <a
           href="#cta-section"
           aria-label="Skip to next section (Bypass 80+ social links)"
-          class="absolute left-[-10000px] focus:static page-button blue-button mobile:h-auto mobile:w-[70%] md:w-[300px] px-5 py-3"
+          class="absolute -z-10 opacity-0 focus:static focus:z-auto focus:opacity-100 page-button blue-button mobile:h-auto mobile:w-[70%] md:w-[300px] px-5 py-3"
         >
           Skip to next section
         </a>

--- a/src/pages/AboutUs/Volunteers/Volunteers.vue
+++ b/src/pages/AboutUs/Volunteers/Volunteers.vue
@@ -11,7 +11,7 @@ onMounted(() => {
 
 <template>
   <div class="font-poppins flex justify-center mb-10">
-    <div class="w-full p-5 h-auto">
+    <div class="w-full h-auto">
       <!-- Section Header -->
       <div class="w-full">
         <h3 class="page-header-accent">OUR TEAM</h3>
@@ -19,6 +19,23 @@ onMounted(() => {
       <div class="w-full mb-10">
         <h2 class="page-header">Volunteers for Good</h2>
       </div>
+
+      <!-- WCAG: Avoid excessive tab stops 
+        - Hidden until focused 'Skip' link
+        - Exists in DOM & is keyboard accessible: Focus via Tab + Enter to jump
+        - Bypass 80+ social media links
+        - Link offers quick jump to next section ('Join our Team')
+      -->
+      <div class="page-button-flex relative">
+        <a
+          href="#cta-section"
+          aria-label="Skip to next section (Bypass 80+ social links)"
+          class="absolute left-[-10000px] focus:static page-button blue-button mobile:h-auto mobile:w-[70%] md:w-[300px] px-5 py-3"
+        >
+          Skip to next section
+        </a>
+      </div>
+
       <!-- Volunteer Staff Section -->
       <div
         class="p-5 w-full my-10 flex flex-col gap-10 items-center justify-between"
@@ -27,9 +44,11 @@ onMounted(() => {
       >
         <VolunteerStaff :staffTitle="item.staffTitle" :staff="item.staff" />
       </div>
+
       <!-- Call to Action -->
       <div
-        class="w-full my-36 flex flex-col justify-center items-center gap-10"
+        id="cta-section"
+        class="w-full py-24 flex flex-col justify-center items-center gap-10"
       >
         <h4 class="text-center page-text">
           Be part of this journey to change lives,


### PR DESCRIPTION
## $\color{Emerald}{Before: \ Accessibility \ Issues}$

### 1. "Team" Page: 85+ Time-Consuming Tab Stops

<details>
 <summary>details</summary>

* 54 volunteer cards listed & ea/ card includes up to 4 social links
  * Keyboard users must currently:
    * **A. Traverse thru 85+ tab stops** → Up to 216, if all cards were fully populated
    * **B. OR Press <kbd>Space</kbd> repeatedly** to 'scroll' past all cards → **~34x** on `mobile` breakpoints, or **~12x** on `xl`
* **Blocks access to informational content / CTA** → "Join the team", "Carl's Journey", & `<Footer/>`
  * SR / keyboard access. barrier → Noisy & time-consuming
  * Violates [WCAG Success Criteria 2.4.1](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html) (Bypass Blocks)
 
</details>

---

## $\color{Emerald}{After: \ WCAG \ Fixes}$

### 1. Team Page: Add Focus-based 'Skip to Next Section' Button

<details>
 <summary>details</summary>

* Add a **hidden-until-focused** <kbd>'Skip'</kbd> button
  - UI appears when `focus`ed
  - Default state: UI visually hidden to avoid visual clutter
  - Exists in DOM & maintains natural, correct tab order
* **Sighted / mouse users:** UI hidden
* **SR & keyboard users only:** Option to jump to the "Join our team" section (CTA)
  - **Focus / Show button:** <kbd>Tab</kbd>
  - **Optional Section jump:** <kbd>Enter</kbd> 
  - **OR** Ignore <kbd>'Skip'</kbd> option & tab thru social links: <kbd>Tab</kbd> 

</details>

### 2. Minor Refactor
- **Refactor:** Replaced custom `checkDeviceType.js` import w/ native Tailwind RWD (in "Team" Page)

---

## $\color{Emerald}{Previews}$

### A. If <kbd>'Skip'</kbd> Clicked → Section Jump
<details>
 <summary>View</summary>

| SR Output | 
| :---: | 
| <img width="300" alt="aria label for hidden until focus skip link team page" src="https://github.com/user-attachments/assets/19df3635-1bb0-400e-8f05-cee88fccefdd" /> | 

| VoiceOver Demo |
| :---: |
| <video src="https://github.com/user-attachments/assets/ef41a27c-1942-486f-af87-ec37b1078884" width="500" /> | 
 
</details>

### B. Else: <kbd>'Skip'</kbd> Ignored → Tab Order Continues to Social Links

<details>
 <summary>View</summary>

| VoiceOver Demo |
| :---: |
| <video src="https://github.com/user-attachments/assets/bb07314b-eb26-42ab-b757-6d7d666fe642" width="500" /> | 
 
</details>

---

## $\color{Emerald}{Manual \ Tests}$

* **Checked RWD:** `1680px` down to `350px`
* **Lighthouse Accessibility Score:** 100 (unchanged; no issues reported on "Team" Page)
* **Visibility for <kbd>'Skip'</kbd> button:** UI hidden until focused
  
---

### Testing Checklist
> I've tested for correct tab order, but here's a checklist for clarity / PR review.

<details>
 <summary>View checklist</summary>

- [x] **1. <kbd>'Skip'</kbd> Btn Focus:** Tab thru the main navbar until reaching the last "Game Zone" link. Press <kbd>Tab</kbd> again → **Expect:** <kbd>'Skip to next section'</kbd> button now appears & receives focus

- [x] **2. <kbd>'Skip'</kbd> Btn Selected:** With the <kbd>'Skip'</kbd> button focused, press <kbd>Enter</kbd> → **Expect:** Page auto-jumps to 'Join Our Team' section

- [x] **3. <kbd>'Skip'</kbd> Btn Ignored:** Follow Step # 1 above. With the <kbd>'Skip'</kbd> button focused, press <kbd>Tab</kbd> → **Expect:** Focus moves to 1st social link (Crystal's LinkedIn) & <kbd>'Skip'</kbd> button disappears

</details>