### PR TITLE
fix: Optimize `.m4a` caching to improve Vercel FDT & game load times

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -114,7 +114,7 @@
   ],
   "headers": [
     {
-      "source": "/(.*)\\.(js|css|woff2?|ttf|eot|svg|png|jpg|jpeg|gif|webp|avif|ico|pdf|mp3|mp4)",
+      "source": "/(.*)\\.(js|css|woff2?|ttf|eot|svg|png|jpg|jpeg|gif|webp|avif|ico|pdf|mp3|mp4|m4a)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Summary
- **One-line fix** in `vercel.json` to cache missing audio extensions
- **Benefits:** Optimizes asset loading for **36 games** (prev. unaccounted for) & reduces Vercel bandwidth and billable **Fast Data Transfer**
- **Before:** Caching rules covered only `.mp3` and `.mp4` (16 of 52 games)
- **After:** All 52 games now benefit from caching intro audio

---

## Screenshots

### 1. Affected Games (36)

>  "`.m4a`" Search results for `src/config/gameConfigs.js` 
<details>
  <summary>View</summary>

| Uncached Game Audio Assets | 
| :--: |
| <img width="250" alt="gameConfigs m4a intro audios" src="https://github.com/user-attachments/assets/20bf128f-ab36-4288-a198-279ca43b88ef" /> |

</details>

### 2. Network Audit: Audio Caching Success

> Sample audit for 'Matter Mix-Up' game

#### 2a. Cache Comparison: `main` vs `fix` PR
<details>
  <summary>View</summary>

#### 1st Visit (Network Fetch)
| Both `main` & `fix` PR | 
| :---: | 
| <img width="953" height="48" alt="first fetch" src="https://github.com/user-attachments/assets/c5c74c00-aa72-4c80-8029-a59cc3ba001b" /> |

#### 2nd Visit 
| `main` | 
| :---: | 
| <i>**1st Row:** Uncached `.m4a`; **2nd Row:** Only `.mp3` cached</i> <br><br> <img width="780" height="45" alt="main live site network audit only mp3 cached" src="https://github.com/user-attachments/assets/f9e41450-4ceb-480b-b8b1-b6cc68af3bb8" /> |

| **`fix` PR** |
| :---: |
| <i>**Both Rows:** Cache hit</i><br><br> <img width="779" height="43" alt="2nd cache hit matter mixup" src="https://github.com/user-attachments/assets/23358f51-60d5-4f38-b132-02055a96361e" /> | 

</details>

#### 2b. Cache Header: `matterIntro.m4a`
<details>
  <summary>View</summary>

| `main`: No caching | `fix` PR: Caching |
| :---: |:---: |
| <img width="506" height="103" alt="cache header main no cache" src="https://github.com/user-attachments/assets/c2554451-2a6b-4060-95e5-d56f68bbe0a6" /> | <img width="424" height="182" alt="network tab cache headers" src="https://github.com/user-attachments/assets/27335945-8163-4a03-a7ba-56e995cf8f14" /> | 

</details>

---

## Manual Tests
- Deployed on personal Vercel
- **Gameplay & Audio:** Remain functional across multiple games
- **Cache Hit:** Tested in Incognito mode; confirmed `.m4a` assets return `(disk cache)` on 2nd load

---

## Notes

- While the payload is small (~0.1 kB) for repeat visits, uncached audio still introduces latency & counts towards billable Vercel usage across the 36 affected games