### PR TITLE
refactor: CSS to Tailwind (Sitewide)

### DIFF
--- a/src/pages/AudioConsole/AudioConsole.vue
+++ b/src/pages/AudioConsole/AudioConsole.vue
@@ -163,7 +163,7 @@ const impactCardsData = [
           :bottomRightImgPath="OrangeStar"
           :topRightImgPath="Book"
           :bottomLeftImgPath="Mic"
-          increaseIconSize="true"
+          :increaseIconSize="true"
         />
         <!-- Console Image -->
         <img
@@ -357,7 +357,7 @@ const impactCardsData = [
           :bottomRightImgPath="YellowStar"
           :topRightImgPath="OrangeStar"
           :bottomLeftImgPath="OrangeStar"
-          increaseIconSize="true"
+          :increaseIconSize="true"
         />
         <h1 class="game-resource-header">
           <p>

--- a/src/pages/GameToolkit/GameToolkit.vue
+++ b/src/pages/GameToolkit/GameToolkit.vue
@@ -1153,7 +1153,9 @@ const cardData = [
           <div
             class="logo-carousel relative w-full overflow-hidden mt-[40px] tablet:mt-[72px] mb-[63px]"
           >
-            <div class="logo-track animate-scroll flex w-max">
+            <div
+              class="logo-track animate-scroll md:[animation-duration:15s] lg:[animation-duration:20s] hover:[animation-play-state:paused] flex w-max"
+            >
               <div
                 class="logo-slide mobile:my-0 mobile:mx-2 mobile:min-w-[80px] flex shrink-0 items-center justify-center my-0 mx-4 min-w-[100px] md:mx-8 md:min-w-[120px]"
                 v-for="(logoMap, count) in carouselLogos"
@@ -1349,23 +1351,3 @@ const cardData = [
 
   <Footer />
 </template>
-
-<style scoped>
-/* Pause animation on hover */
-.logo-carousel:hover .logo-track {
-  animation-play-state: paused;
-}
-
-/* Responsive adjustments */
-@media (max-width: 768px) {
-  .logo-track {
-    animation-duration: 15s;
-  }
-}
-
-@media (max-width: 600px) {
-  .logo-track {
-    animation-duration: 12s;
-  }
-}
-</style>

--- a/src/pages/GameToolkit/GameToolkitButton.vue
+++ b/src/pages/GameToolkit/GameToolkitButton.vue
@@ -5,7 +5,7 @@
  * - Component used in Gallery and Database sections
  */
 
-import { computed, defineEmits, watch } from 'vue';
+import { computed, watch } from 'vue';
 
 /* --- PROPS --- */
 

--- a/src/pages/GameZone/GameZone.vue
+++ b/src/pages/GameZone/GameZone.vue
@@ -379,8 +379,8 @@ function hideMenuDropdown(menuBtn, currentDropdown) {
           id="game-zone-header"
           class="font-poppins text-black text-[40px] mobile:text-[25px] mobile:text-center M-0 min-[768px]:max-[1024px]:mt-0"
         >
-          <em style="color: #077bb3"> Play </em> and
-          <em style="color: #fe892a"> learn </em> with us!
+          <em class="text-primary-color"> Play </em> and
+          <em class="text-secondary-color"> learn </em> with us!
         </h2>
         <div
           id="game-zone-grid"

--- a/src/pages/GameZone/GameZoneLandingPage.vue
+++ b/src/pages/GameZone/GameZoneLandingPage.vue
@@ -78,9 +78,9 @@ const gameMenusMap = [
         <h2
           class="font-poppins text-black text-[40px] mobile:text-[25px] mobile:text-center mb-[3%]"
         >
-          <em style="color: #077bb3">Explore</em>
+          <em class="text-primary-color">Explore</em>
           our
-          <em style="color: #fe892a">Games</em>
+          <em class="text-secondary-color">Games</em>
         </h2>
         <div
           class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-10 sm:gap-10 text-[#323232] mb-10"

--- a/src/pages/Home/TechShowcase/TechShowcase.vue
+++ b/src/pages/Home/TechShowcase/TechShowcase.vue
@@ -15,8 +15,7 @@ const videoVisible = ref(false);
 let showTooltipMsg = ref(false);
 
 // Check device type
-// NOTE: Current UI logic only uses 'isTablet' flag
-const { isTablet } = useDeviceDetection();
+const { isTablet, isDesktop } = useDeviceDetection();
 
 let observer;
 
@@ -85,7 +84,10 @@ const exitVideoControls = () => {
 <template>
   <div
     class="lg:relative flex items-center flex-col lg:flex-row justify-center items-center gap-x-5 gap-y-16 md:gap-y-0 py-10 my-10"
-    :class="{ 'tablet-showcase': isTablet }"
+    :class="[
+      isDesktop ? 'gap-24 justify-between pl-0 pr-8' : '',
+      isTablet ? 'flex items-center' : '',
+    ]"
     role="none"
   >
     <!-- Decorative icons (medium+ screens) -->
@@ -163,10 +165,7 @@ const exitVideoControls = () => {
           <!-- Poster image -->
           <div
             v-if="!isPlaying"
-            class="w-full h-full bg-cover bg-center"
-            style="
-              background-image: url('/assets/images/techShowcase/video-poster-resized.png');
-            "
+            class="w-full h-full bg-cover bg-center bg-[url('/assets/images/techShowcase/video-poster-resized.png')]"
             aria-hidden="true"
           ></div>
 
@@ -180,7 +179,7 @@ const exitVideoControls = () => {
           >
             <div
               aria-hidden="true"
-              class="tra absolute w-[22px] h-[22px] top-[50%] left-[50%] translate-x-[-40%] bg-black translate-y-[-50%] rotate-90"
+              class="clip-triangle absolute w-[22px] h-[22px] top-[50%] left-[50%] translate-x-[-40%] bg-black translate-y-[-50%] rotate-90"
             ></div>
           </div>
 
@@ -208,10 +207,7 @@ const exitVideoControls = () => {
     <div
       class="w-full md:w-3/5 flex items-center flex-col lg:flex-row justify-center items-center"
     >
-      <div
-        class="text-center w-[80%] md:p-10"
-        :class="{ 'tablet-text-container': isTablet }"
-      >
+      <div class="text-center w-[80%] md:p-10" :class="{ 'pr-6': isTablet }">
         <h1 class="page-header">
           Games are more accessible when they
           <span class="text-primary-color font-[700]">talk back</span>
@@ -240,27 +236,3 @@ const exitVideoControls = () => {
     </div>
   </div>
 </template>
-
-<style scoped>
-.tra {
-  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-}
-
-.tablet-showcase {
-  gap: 6rem;
-  justify-content: space-between;
-  padding: 0 2rem;
-}
-
-.tablet-text-container {
-  padding-right: 1.5rem;
-}
-
-@media (min-width: 768px) and (max-width: 1023px) {
-  .tablet-showcase {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-  }
-}
-</style>

--- a/src/pages/Impact/CollaboratingSchools/Map.vue
+++ b/src/pages/Impact/CollaboratingSchools/Map.vue
@@ -1,5 +1,9 @@
 <template>
-  <div id="map" ref="mapRef">
+  <div
+    id="map"
+    class="h-[80vh] w-[80vw] m-auto rounded-xl shadow-[0_4px_8px_rgba(0,0,0,0.2)] md:shadow-none md:h-[45vh] md:w-[35vw] md:rounded-2xl"
+    ref="mapRef"
+  >
     <p v-if="!mapVisible" class="text-center text-sm text-gray-500 mt-4">
       Loading map...
     </p>
@@ -193,20 +197,3 @@ onUnmounted(() => {
   if (observer) observer.disconnect();
 });
 </script>
-
-<style>
-#map {
-  height: 45vh;
-  width: 35vw;
-  border-radius: 16px;
-}
-@media (max-width: 768px) {
-  #map {
-    height: 80vw;
-    width: 80vw;
-    border-radius: 12px;
-    margin: 0 auto;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  }
-}
-</style>

--- a/src/pages/Impact/OurReach/OurReach.vue
+++ b/src/pages/Impact/OurReach/OurReach.vue
@@ -44,7 +44,7 @@ const impactImages = [
       :bottomRightImgPath="OrangeStar"
       :topRightImgPath="SpeechBubble"
       :bottomLeftImgPath="YellowStar"
-      increaseIconSize="true"
+      :increaseIconSize="true"
     />
     <!-- Uniform Image Grid with Slight Tilt -->
     <div

--- a/src/pages/OurProjects/ProjectsInAction/ProjectsInAction.vue
+++ b/src/pages/OurProjects/ProjectsInAction/ProjectsInAction.vue
@@ -47,7 +47,7 @@ const impactImages = [
       :topLeftImgPath="BlueStar"
       :bottomLeftImgPath="OrangeStar"
       :bottomRightImgPath="YellowStar"
-      increaseIconSize="true"
+      :increaseIconSize="true"
     />
     <div
       class="flex items-center flex-col w-full lg:flex-row lg:w-1/2 justify-center"

--- a/src/pages/OurProjects/ResearchTech/ResearchTech.vue
+++ b/src/pages/OurProjects/ResearchTech/ResearchTech.vue
@@ -55,9 +55,7 @@ const items2 = [
           We conduct
           <span class="font-semibold"> research on accessibility </span> in the
           field of AI and Computer Science to make sure
-          <span style="color: #077bb3" class="font-semibold">
-            Audemy's games
-          </span>
+          <span class="font-semibold text-primary-color"> Audemy's games </span>
           stay as <span class="font-semibold"> accessible as possible. </span>
         </p>
       </div>

--- a/src/pages/OurProjects/Social/SocialMedia.vue
+++ b/src/pages/OurProjects/Social/SocialMedia.vue
@@ -44,11 +44,10 @@
       >
         <div class="w-full h-full aspect-video max-w-[100%] max-h-[90%]">
           <iframe
-            class="w-full h-full rounded-[15px]"
+            class="w-full h-full rounded-[15px] pointer-events-auto"
             src="https://www.youtube.com/embed?listType=playlist&list=UU_QnL2hAtkxcMUNYBUFm6rQ"
             frameborder="0"
             allowfullscreen
-            style="pointer-events: auto"
             title="Pet Names and Fun Facts for Kids (Youtube Video)"
           ></iframe>
         </div>

--- a/src/style.css
+++ b/src/style.css
@@ -28,9 +28,13 @@
   @apply flex mobile:flex-col justify-center items-center text-center my-10;
 }
 
-/* --- Pattern: White bg with grey crossed-lines --- */
+/* --- Patterns: White bg with grey crossed-lines --- */
 .bg-cross-lines {
   @apply bg-white bg-[linear-gradient(to_right,#e0e0e0_1px,transparent_1px),linear-gradient(to_bottom,#e0e0e0_1px,transparent_1px)] bg-[size:24px_24px];
+}
+
+.clip-triangle {
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
 }
 
 /* --- Hover: Slight zoom in animation --- */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,7 +55,7 @@ export default {
       animation: {
         'fade-slide-in': 'fade-slide-in 0.2s ease-out forwards',
         'fade-slide-out': 'fade-slide-out 0.2s ease-in forwards',
-        scroll: 'scroll 20s linear infinite',
+        scroll: 'scroll 12s linear infinite',
       },
     },
   },


### PR DESCRIPTION
# Summary
- This PR refactors complex CSS queries/rules into shared, native Tailwind sitewide
- **Benefits:** Reduced **58 net LOC** while improving maintainability & consistency

## Refactor Scope
- **Game Toolkits**
- **Game Zone**
- **Game Zone Landing Page**
- **Home** → `Tech Showcase`
- **Impact** → `Map`, `Social Media`, & `Research Tech`

---

# Approach

## 1. CSS → Tailwind
- Replaced custom `@media` queries in `<style>` blocks with native Tailwind RWD classes
- Updated the global `style.css` to support shared patterns

## 2. Minor Fixes
- **Syntax Fix:** Resolved `v-binding` typos (missing colons `:`) to ensure `props` are correctly interpreted as `Booleans` (not `String`)
- **Cleanup:** Removed redundant imports for Vue macros (`defineEmits`)

---

# Vercel Previews: Tailwind Refactor

> Below are demos for the 3 components with the most significant refactoring impact

## 1. Game Toolkits: Carousel

<details>
<summary> View animation & pause-on-hover effects  </summary>

| Mobile / Small |
| :---: |
| <video src="https://github.com/user-attachments/assets/15eacb63-4ea6-4285-af42-06289747e002" width="200"/> | 

| Medium |
| :---: | 
| <video src="https://github.com/user-attachments/assets/7045730a-17f4-4f57-a305-3b00d4884e03" width="300"/> | 

| Large+ |
| :---: | 
| <video src="https://github.com/user-attachments/assets/f41c59a2-5cc4-4819-9d7c-86828ca18318" width="400"/> | 

</details>

## 2. Impact: School Map

<details>
<summary> View RWD & functionality (TomTom API)</summary>

| Mobile (`sm`) | Tablet (`md`) | Desktop (`lg+`) |
| :---: |:---: |:---: |
| <img src="https://github.com/user-attachments/assets/ac1870d7-2bc0-4d56-9e8b-f5766c9a77b2" width="200"/> | <img src="https://github.com/user-attachments/assets/8a72056f-a726-461a-82a9-7ff2ce422c32" width="300" /> | <img src="https://github.com/user-attachments/assets/1ce83f40-e0d6-4861-ab65-f066e22ae7fc" width="300"/> | 

</details>

## 3. Home: "Tech Showcase" 

<details>
<summary> View RWD for Home video poster</summary>

| Mobile (`sm`) | Tablet (`md`) | Desktop (`lg+`) |
| :---: |:---: |:---: |
| <img src="https://github.com/user-attachments/assets/694480ee-7e22-4a35-a335-d9d299a00efd" width="200"/> | <img src="https://github.com/user-attachments/assets/3a4b9d71-a202-4fdf-b4a6-b2987dbfa870" width="300"/> | <img src="https://github.com/user-attachments/assets/edeb9c6b-93cb-47ef-8b31-e8b7b53ff2f9" width="300"/> | 

</details>

---

# Manual Tests
- **No console errors:** Deployed on personal Vercel
- **RWD Check:** Responsive from `1680px` down to `350px`
- **Cross-Device/Browser Check:** Desktop, Tablet, & Mobile (Chrome / Safari)
- **Gameplay:** Sampled 3 games