### PR TITLE
fix: Auto-close mobile menu (WCAG) + refactor `<Footer/>` for DRY templates

### DIFF
--- a/src/components/Header/Header.vue
+++ b/src/components/Header/Header.vue
@@ -160,12 +160,14 @@
       v-if="(isMobileView || isTabletView) && isMenuOpen"
       class="fixed inset-0 bg-black bg-opacity-50 z-40"
       @click="closeMenu"
+      aria-hidden="true"
     ></div>
 
     <!-- Mobile Slide-in Menu -->
     <div
       v-if="(isMobileView || isTabletView) && isMenuOpen"
       class="fixed inset-y-0 right-0 bg-white z-50 w-4/5 max-w-xs flex flex-col overflow-y-auto"
+      @focusout="handleNavFocusOut"
     >
       <div class="flex justify-end p-7 px-10">
         <button
@@ -522,6 +524,18 @@ const logout = () => {
 const closeAlert = () => {
   showAlert.value = false;
 };
+
+// WCAG: Auto-close mobile nav if tabbing past last menu link (Youtube)
+function handleNavFocusOut(event) {
+  const mobileNav = event.currentTarget;
+
+  // Keep mobile menu open if focus is still within it (e.g., tabbing through it)
+  if (mobileNav.contains(event.relatedTarget)) {
+    return;
+  } else {
+    closeMenu();
+  }
+}
 
 // Add resize listener to check screen size
 onMounted(() => {

--- a/src/pages/Footer/PrivacyPolicy.vue
+++ b/src/pages/Footer/PrivacyPolicy.vue
@@ -2,6 +2,40 @@
 import Banner from '../../components/AccountPages/Banner.vue';
 import Header from '../../components/Header/Header.vue';
 import Footer from '../../components/Footer/Footer.vue';
+
+// List of 'Privacy Policy' sections
+const policySections = [
+  {
+    header: `We Don't Collect Personal Data`,
+    details: `Audemy is a safe space for kids. We do not collect, store, or share any personal information.`,
+  },
+  {
+    header: 'For Kids, with Care',
+    details: `Audemy is built especially for blind and visually impaired students. We designed everything to be private and accessible. You can play our games and learn without an account or providing any personal details.`,
+  },
+  {
+    header: 'COPPA-Compliant',
+    details: `We follow the
+          <a
+            href="https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa"
+            target="_blank"
+            class="page-link"
+          >
+            Children's Online Privacy Protection Act
+          </a>
+          (COPPA). Since we don't collect any information from users under 13—or
+          anyone, really—there's nothing for us to protect. And that's exactly
+          how we like it.`,
+  },
+  {
+    header: 'Anonymous Use Only',
+    details: `All interactions with Audemy are completely anonymous. Your activity is not tracked, and we do not use cookies or analytics tools that collect user data.`,
+  },
+  {
+    header: 'Questions?',
+    details: `If you're a parent, teacher, or guardian and would like to learn more, contact us at <a href="mailto:connect@audemy.org" class="page-link">connect@audemy.org</a>.`,
+  },
+];
 </script>
 
 <template>
@@ -32,60 +66,25 @@ import Footer from '../../components/Footer/Footer.vue';
           respect and take your privacy very seriously. We created this policy
           to explain—clearly and simply—how we handle your information.
         </p>
-        <h2 class="page-subheader">We Don’t Collect Personal Data</h2>
-        <p>
-          Audemy is a safe space for kids. We do not collect, store, or share
-          any personal information.
-        </p>
-        <br />
-        <div>
-          <p
-            class="font-semibold text-primary-color border-b-2 border-primary-color"
-          >
-            That means:
-          </p>
-          <ul class="list-disc text-left ml-[15%] lg:ml-[20%]">
-            <li>No names</li>
-            <li>No email addresses</li>
-            <li>No phone numbers</li>
-            <li>No photos, voice recordings, or other personal content</li>
-            <li>No cookies or trackers</li>
-          </ul>
+        <div v-for="(policy, n) in policySections" :key="n">
+          <h2 class="page-subheader">{{ policy.header }}</h2>
+          <p v-html="policy.details"></p>
+          <br />
+          <template v-if="n == 0">
+            <p
+              class="font-semibold text-primary-color border-b-2 border-primary-color"
+            >
+              That means:
+            </p>
+            <ul class="list-disc text-left ml-[15%] lg:ml-[20%]">
+              <li>No names</li>
+              <li>No email addresses</li>
+              <li>No phone numbers</li>
+              <li>No photos, voice recordings, or other personal content</li>
+              <li>No cookies or trackers</li>
+            </ul>
+          </template>
         </div>
-        <h2 class="page-subheader">For Kids, with Care</h2>
-        <p>
-          Audemy is built especially for blind and visually impaired students.
-          We designed everything to be private and accessible. You can play our
-          games and learn without an account or providing any personal details.
-        </p>
-        <h2 class="page-subheader">COPPA-Compliant</h2>
-        <p>
-          We follow the
-          <a
-            href="https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa"
-            target="_blank"
-            class="page-link"
-          >
-            Children’s Online Privacy Protection Act
-          </a>
-          (COPPA). Since we don’t collect any information from users under 13—or
-          anyone, really—there’s nothing for us to protect. And that’s exactly
-          how we like it.
-        </p>
-        <h2 class="page-subheader">Anonymous Use Only</h2>
-        <p>
-          All interactions with Audemy are completely anonymous. Your activity
-          is not tracked, and we do not use cookies or analytics tools that
-          collect user data.
-        </p>
-        <h2 class="page-subheader">Questions?</h2>
-        <p>
-          If you’re a parent, teacher, or guardian and would like to learn more,
-          contact us at
-          <a href="mailto:connect@audemy.org" class="page-link"
-            >connect@audemy.org</a
-          >.
-        </p>
       </div>
     </div>
   </div>

--- a/src/pages/Footer/TermsOfUse.vue
+++ b/src/pages/Footer/TermsOfUse.vue
@@ -3,7 +3,51 @@ import Banner from '../../components/AccountPages/Banner.vue';
 import Header from '../../components/Header/Header.vue';
 import Footer from '../../components/Footer/Footer.vue';
 
+// List of 'Terms of Use' sections
+const termSections = [
+  {
+    header: 'Eligibility',
+    details: `Our Services are designed for students, parents, and educators.`,
+  },
+  {
+    header: 'Data and Privacy',
+    details: `Audemy does not collect, store, or share any personal data from
+              users. Our Services are designed to be used without requiring
+              accounts, personal information, or data tracking. Because no user
+              data is collected or stored, there is no risk of your personal
+              information being sold or disclosed.`,
+  },
+  {
+    header: 'Purpose of Services',
+    details: `Audemy provides AI‑powered, educational games designed to support
+              blind and visually impaired students, as well as the broader
+              learning community. The Services are for educational and personal
+              use only and may not be used for commercial resale or distribution
+              without written permission.`,
+  },
+  {
+    header: 'Limitation of Liability',
+    details: `Our Services are provided “as-is,” without warranties of any kind.
+              Since no personal data is collected or stored, Audemy is not
+              responsible for any data loss or unauthorized access to personal
+              information.`,
+  },
+  {
+    header: 'Contact Us',
+    details: `If you have any questions about these Terms, please contact us:`,
+  },
+];
+
 // Extracted Tailwind classes for readability and DRYer code
+const contactInfo = [
+  {
+    label: 'Email',
+    text: 'connect@audemy.org',
+    link: 'mailto:connect@audemy.org',
+  },
+  { label: 'Website', text: 'www.audemy.org', link: 'https://audemy.org/' },
+];
+
 const contactListClasses = [
   'flex',
   'flex-col',
@@ -54,76 +98,27 @@ const contactLinkClasses = ['page-link', 'justify-self-end'];
           “Services”). By using our Services, you agree to these Terms.
         </p>
         <ol>
-          <li>
-            <h2 class="page-subheader">1. Eligibility</h2>
-            <p>
-              Our Services are designed for students, parents, and educators.
-            </p>
-          </li>
-          <li>
-            <h2 class="page-subheader">2. Data and Privacy</h2>
-            <p>
-              Audemy does not collect, store, or share any personal data from
-              users. Our Services are designed to be used without requiring
-              accounts, personal information, or data tracking. Because no user
-              data is collected or stored, there is no risk of your personal
-              information being sold or disclosed.
-            </p>
-          </li>
-          <li>
-            <h2 class="page-subheader">3. Purpose of Services</h2>
-            <p>
-              Audemy provides AI‑powered, educational games designed to support
-              blind and visually impaired students, as well as the broader
-              learning community. The Services are for educational and personal
-              use only and may not be used for commercial resale or distribution
-              without written permission.
-            </p>
-          </li>
-          <li>
-            <h2 class="page-subheader">4. Intellectual Property</h2>
-            <p>
-              All content, games, software, and materials provided through
-              Audemy are the property of Audemy or its licensors. You may not
-              reproduce, sell, or exploit any part of the Services without prior
-              written consent.
-            </p>
-          </li>
-          <li>
-            <h2 class="page-subheader">5. Limitation of Liability</h2>
-            <p>
-              Our Services are provided “as-is,” without warranties of any kind.
-              Since no personal data is collected or stored, Audemy is not
-              responsible for any data loss or unauthorized access to personal
-              information.
-            </p>
-          </li>
-          <li>
-            <h2 class="page-subheader">6. Contact Us</h2>
-            <p>
-              If you have any questions about these Terms, please contact us:
-            </p>
-            <br />
-            <!-- Responsive Container for Email + Website
-                - Parent (list): flex column; inner (each list item): 2-column grid
-            -->
-            <ul :class="contactListClasses">
-              <li class="grid grid-cols-2">
-                <span :class="contactLabelClasses">Email:</span>
-                <a href="mailto:connect@audemy.org" :class="contactLinkClasses"
-                  >connect@audemy.org</a
+          <li v-for="(term, n) in termSections" :key="n">
+            <h2 class="page-subheader">{{ n + 1 }}. {{ term.header }}</h2>
+            <p>{{ term.details }}</p>
+            <template v-if="term.header == 'Contact Us'">
+              <br />
+              <!-- Responsive Container for Email + Website
+                  - Parent (list): flex column; inner (each list item): 2-column grid
+              -->
+              <ul :class="contactListClasses">
+                <li
+                  v-for="(contact, n) in contactInfo"
+                  :key="n"
+                  class="grid grid-cols-2"
                 >
-              </li>
-              <li class="grid grid-cols-2">
-                <span :class="contactLabelClasses">Website:</span>
-                <a
-                  href="https://audemy.org/"
-                  target="_blank"
-                  :class="contactLinkClasses"
-                  >www.audemy.org</a
-                >
-              </li>
-            </ul>
+                  <span :class="contactLabelClasses">{{ contact.label }}:</span>
+                  <a :href="contact.link" :class="contactLinkClasses">{{
+                    contact.text
+                  }}</a>
+                </li>
+              </ul>
+            </template>
           </li>
         </ol>
       </div>


### PR DESCRIPTION
# Summary
- **WCAG Fix:** Resolves **keyboard accessibility** barrier in the nav menu across all responsive views (mobile/tablet/desktop-resized)
- **Refactor:** Improves **maintainability** of `<Footer/>` pages by replacing WET, hardcoded logic with data-driven templates

## Details
- **Issue:** Closes #288 by implementing auto-close logic for mobile menu and overlay on `@focusout`
- **Scope:** `Header`, `Privacy Policy`, & `Terms of Use` 


---

# Approach

##  1. WCAG Fix: Auto-Close Mobile Menu
- **Before:** 
  - Mobile menu and overlay remained open even after a keyboard user tabbed past the last menu item (YouTube)
  - This open state visually obscured the main content and next focusable elements
  - Keyboard users were forced to press <kbd>Shift+Tab</kbd> **12x** to return to the `X` (close) button
- **After:** 
  - Added a `@focusout` listener (`handleNavFocusOut()`) 
  - Mobile menu and decorative overlay now auto-close on focus out, ensuring the next focusable element & main content is visible
- **WCAG Success Criteria:** Keyboard Accessibility & Focus Visible

##  2. DRY Refactor: `<Footer/>` Pages
- Use structured JavaScript objects, implementing dynamic `v-for` loops for UI rendering 
- Replace hardcoded, redundant templates

---

# Vercel Previews: WCAG Fix

## Before

<details>
<summary>View demo</summary>

| Opened Navbar Obscures Next Focusable Elements | 
|  :---: |
| <video src="https://github.com/user-attachments/assets/21e52fe0-e006-4236-afc4-48580048166d" width="500"></video> |


</details>

## After 

<details>

<summary>View demo</summary>

> Tabbing past mobile menu closes it and brings focus to <kbd>"Play Our Games!"</kbd>

| Auto-Close Mobile Menu & Overlay | 
|  :---: |
| <video src="https://github.com/user-attachments/assets/bfbf748c-e936-44d7-9f23-e88b81a8aa68" width="500"></video> |

</details>

---


# Manual Tests
- **No console errors:** Deployed on personal Vercel
- **RWD Check:** Responsive from `1680px` down to `350px`
- **Correct Focus Order:** **After tabbing out** of the mobile menu, focus lands correctly on the **first focusable element** of the page

## 1st Focusable Element & Page "Mapping"

<details>
<summary>View "map"</summary>

| Page | First Focusable Element | 
| :---: | :---: |
| Home | <kbd>Play Our Games!</kbd> |
| Team | <kbd>Skip to Next Section</kbd> |
| Impact | <kbd>Partnered Staff</kbd> (1st Filter Tab) |
| Our Projects | Left Arrow  (`⬅`) for Carousel |
| Press | ["Forbes 30 Under 30"](https://www.forbes.com/profile/crystal-yang/) Link |
| Buzzle | <kbd>Learn More</kbd> |
| Accessibility Studio | <kbd>Start Your Accessibility Test</kbd> | 
| Game Toolkits | <kbd>View All Toolkits</kbd> | 
| Game Zone Landing Page | <kbd>"8 Language Games"</kbd> Button |
| Game Zone | <kbd>"Language"</kbd> Filter Button |
| Troubleshooting | connect@audemy.org (email) |
| Terms of Use | connect@audemy.org (email) |
| Privacy Policy | [COOPA](https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa) Link |
| Accessibility Statement | [WCAG](https://www.w3.org/TR/WCAG22/) Link |

</details>

## Test Details: Mobile Navigation & Focus

<details>
<summary>View steps</summary>

1. On desktop, resize to mobile or tablet view (between `350px` and `1024px`)
2. Open the mobile nav icon (`☰`)
3. <kbd>Tab</kbd> thru mobile nav menu, reaching "YouTube" 
4. <kbd>Tab</kbd> once more 
5. Observe mobile menu and overlay both auto-close now, and focus order remains intact, focusing on the first focusable element on the main content.


</details>

---

# Notes/Future Work
- Add identical auto-close logic to `UserAuthHeader.vue` once user auth features resume