### PR TITLE
fix: Vue `v-show` runtime warnings for `<GameControls/>`

### DIFF
--- a/src/components/Game/GameControls.vue
+++ b/src/components/Game/GameControls.vue
@@ -1,114 +1,115 @@
 <template>
-  <div
-    v-show="showControls"
-    :class="[
-      'justify-center',
-      isTablet
-        ? 'flex gap-[25px] mb-6'
-        : isMobile
-          ? 'flex flex-col gap-4 mb-6'
-          : 'flex gap-6 mb-6',
-    ]"
-  >
-    <button
-      @click="onRecordClick"
-      :class="recordButtonClasses"
-      :disabled="isButtonDisabled"
-      :title="recordButtonTitle"
-    >
-      <span class="text-lg font-medium">
-        {{ recordButtonText }}
-      </span>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-        width="24"
-        height="24"
-        fill="currentColor"
-        class="bi bi-mic-fill"
-        viewBox="0 0 16 16"
-      >
-        <path d="M5 3a3 3 0 0 1 6 0v5a3 3 0 0 1-6 0z" />
-        <path
-          d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5"
-        />
-      </svg>
-    </button>
-
-    <button
-      @click="onRepeatClick"
-      :class="[
-        'page-button py-5 px-8 text-nowrap flex gap-2.5 items-center justify-center rounded-[20px]',
-        isTablet
-          ? 'w-[250px] h-[60px]'
-          : isMobile
-            ? 'w-full h-[60px]'
-            : 'w-[250px] h-[116px]',
-        'bg-white border border-[#0096D6] text-[#0096D6]',
-        isIntroPlaying || isButtonCooldown
-          ? 'opacity-50 cursor-not-allowed'
-          : 'hover:bg-gray-200',
-      ]"
-      :disabled="isIntroPlaying || isButtonCooldown"
-      :title="
-        isIntroPlaying
-          ? 'Please wait until the introduction finishes'
-          : isButtonCooldown
-            ? 'Please wait before repeating the question again'
-            : 'Repeat the current question'
-      "
-    >
-      <span class="text-lg font-medium">{{
-        isTablet || isMobile ? 'Repeat' : 'Repeat Question'
-      }}</span>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        aria-hidden="true"
-        width="24"
-        height="24"
-        fill="currentColor"
-        class="bi bi-arrow-repeat"
-        viewBox="0 0 16 16"
-      >
-        <path
-          d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41m-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9"
-        />
-        <path
-          fill-rule="evenodd"
-          d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5 5 0 0 0 8 3M3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9z"
-        />
-      </svg>
-    </button>
-  </div>
-
-  <div
-    v-show="showControls"
-    id="transcript"
-    class="relative bg-cross-lines rounded-[16px] p-4 my-4 shadow-md mx-auto mobile:w-[280px] w-[300px] md:w-[500px] flex flex-col gap-y-4 items-center justify-center"
-  >
+  <!-- Conditonal root wrapper to resolve v-show warning in parent component -->
+  <div v-show="showControls">
     <div
-      class="absolute rounded-t-[16px] top-0 left-0 bg-[#edf7fc] h-[44px] w-full"
-      aria-hidden="true"
+      :class="[
+        'justify-center',
+        isTablet
+          ? 'flex gap-[25px] mb-6'
+          : isMobile
+            ? 'flex flex-col gap-4 mb-6'
+            : 'flex gap-6 mb-6',
+      ]"
     >
-      <!-- Decorative banner (empty) -->
+      <button
+        @click="onRecordClick"
+        :class="recordButtonClasses"
+        :disabled="isButtonDisabled"
+        :title="recordButtonTitle"
+      >
+        <span class="text-lg font-medium">
+          {{ recordButtonText }}
+        </span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          width="24"
+          height="24"
+          fill="currentColor"
+          class="bi bi-mic-fill"
+          viewBox="0 0 16 16"
+        >
+          <path d="M5 3a3 3 0 0 1 6 0v5a3 3 0 0 1-6 0z" />
+          <path
+            d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5"
+          />
+        </svg>
+      </button>
+
+      <button
+        @click="onRepeatClick"
+        :class="[
+          'page-button py-5 px-8 text-nowrap flex gap-2.5 items-center justify-center rounded-[20px]',
+          isTablet
+            ? 'w-[250px] h-[60px]'
+            : isMobile
+              ? 'w-full h-[60px]'
+              : 'w-[250px] h-[116px]',
+          'bg-white border border-[#0096D6] text-[#0096D6]',
+          isIntroPlaying || isButtonCooldown
+            ? 'opacity-50 cursor-not-allowed'
+            : 'hover:bg-gray-200',
+        ]"
+        :disabled="isIntroPlaying || isButtonCooldown"
+        :title="
+          isIntroPlaying
+            ? 'Please wait until the introduction finishes'
+            : isButtonCooldown
+              ? 'Please wait before repeating the question again'
+              : 'Repeat the current question'
+        "
+      >
+        <span class="text-lg font-medium">{{
+          isTablet || isMobile ? 'Repeat' : 'Repeat Question'
+        }}</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          width="24"
+          height="24"
+          fill="currentColor"
+          class="bi bi-arrow-repeat"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M11.534 7h3.932a.25.25 0 0 1 .192.41l-1.966 2.36a.25.25 0 0 1-.384 0l-1.966-2.36a.25.25 0 0 1 .192-.41m-11 2h3.932a.25.25 0 0 0 .192-.41L2.692 6.23a.25.25 0 0 0-.384 0L.342 8.59A.25.25 0 0 0 .534 9"
+          />
+          <path
+            fill-rule="evenodd"
+            d="M8 3c-1.552 0-2.94.707-3.857 1.818a.5.5 0 1 1-.771-.636A6.002 6.002 0 0 1 13.917 7H12.9A5 5 0 0 0 8 3M3.1 9a5.002 5.002 0 0 0 8.757 2.182.5.5 0 1 1 .771.636A6.002 6.002 0 0 1 2.083 9z"
+          />
+        </svg>
+      </button>
     </div>
 
     <div
-      class="relative w-full h-full text-[15.5px] md:text-[16px] 2xl:text-[20px]"
+      id="transcript"
+      class="relative bg-cross-lines rounded-[16px] p-4 my-4 shadow-md mx-auto mobile:w-[280px] w-[300px] md:w-[500px] flex flex-col gap-y-4 items-center justify-center"
     >
-      <div class="relative z-10 font-semibold w-full text-center">
-        You said:
-      </div>
       <div
-        class="mt-1 relative h-full w-full p-1 flex flex-col justify-center items-center"
+        class="absolute rounded-t-[16px] top-0 left-0 bg-[#edf7fc] h-[44px] w-full"
+        aria-hidden="true"
       >
-        <!-- Decorative transparent background for transcript legibility -->
+        <!-- Decorative banner (empty) -->
+      </div>
+
+      <div
+        class="relative w-full h-full text-[15.5px] md:text-[16px] 2xl:text-[20px]"
+      >
+        <div class="relative z-10 font-semibold w-full text-center">
+          You said:
+        </div>
         <div
-          aria-hidden="true"
-          class="-z-1 absolute top-0 left-0 bg-white h-full w-full rounded-[16px]"
-          :class="transcription == '' ? 'opacity-0' : 'opacity-70'"
-        ></div>
-        <div class="relative z-10">{{ transcription }}</div>
+          class="mt-1 relative h-full w-full p-1 flex flex-col justify-center items-center"
+        >
+          <!-- Decorative transparent background for transcript legibility -->
+          <div
+            aria-hidden="true"
+            class="-z-1 absolute top-0 left-0 bg-white h-full w-full rounded-[16px]"
+            :class="transcription == '' ? 'opacity-0' : 'opacity-70'"
+          ></div>
+          <div class="relative z-10">{{ transcription }}</div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Summary
- **Fix runtime Vue warnings:** `"Runtime directive used on component with non-element root node"`
- These warnings are **visible in the local dev** console but **silenced in production** (Vercel deployment)

---

# Approach
- Add a single root `<div>` wrapper in `<GameControls/>` to enable attribute inheritance from the parent game component
- Refactor and extract inner shared `v-show="showControls"` logic to the new root
- Re-run Prettier (**large git diff due to identation**)


## Before
```vue
<template>
  <!-- BEFORE: GameControls.vue (triggers Vue warnings) --> 
  <div v-show="showControls"> ... </div> 
  <div v-show="showControls"> ... </div>
</template>
```

## After
```vue
<template>
  <!-- AFTER: GameControls.vue (+ Necessary root wrapper with shared v-show logic) --> 
  <div v-show="showControls">
    <div> ... </div> 
    <div> ... </div>
  </div>
</template>
```
----

# Screenshots

| Before: Vue Runtime Warnings (multiple instances)  |
| :---: |
| <img width="1052" height="251" alt="Screenshot 2026-03-02 at 2 26 44 PM" src="https://github.com/user-attachments/assets/f0d11af0-ecb7-49e5-926c-d201c6106878" /> | 

| After: Resolved Warnings (caused by `<GameControls/>`) | 
| :----: |
| <img width="1044" height="91" alt="Screenshot 2026-03-02 at 2 07 42 PM" src="https://github.com/user-attachments/assets/6a9ecfa9-5cfa-4639-958b-f61b8bf97036" /> |
 
---

# Manual Tests
- **DevTools Console:** No Vue warnings during gameplay on **local dev** & **personal Vercel** deployment
- **Functional & Responsive Gameplay:** Game controls (record/repeat buttons + transcription) render correctly
- Sampled 1+ games per category