### PR TITLE
fix: Broken `404` Impact, Press List links

### DIFF
--- a/src/pages/Impact/CollaboratingSchools/Affiliates.vue
+++ b/src/pages/Impact/CollaboratingSchools/Affiliates.vue
@@ -55,7 +55,7 @@ const schools = [
   },
   {
     name: 'Florida School for the Deaf and the Blind',
-    link: "https://www.fsdbk12.org'",
+    link: 'https://www.fsdbk12.org',
   },
   {
     name: 'Georgia Academy for the Blind',
@@ -71,7 +71,7 @@ const schools = [
   },
   {
     name: 'Illinois School for the Visually Impaired',
-    link: 'https://www.dhs.state.il.us/page.aspx?item=84503',
+    link: 'https://www.dhs.state.il.us',
   },
   {
     name: 'Indiana School for the Blind and Visually Impaired',
@@ -178,7 +178,7 @@ const teachers = [
   },
   {
     name: 'Kansas State School for the Deaf and Blind (KSSDB)',
-    link: 'https://www.kssdb.org/',
+    link: 'https://kansasblind.gov/',
     educators: [
       {
         name: 'Kimberly Rhea',

--- a/src/pages/Impact/PressList/PressList.vue
+++ b/src/pages/Impact/PressList/PressList.vue
@@ -133,13 +133,13 @@ const items = [
     image: 'Devdiscourse.png',
     text: 'AI-powered audio gaming boosts accessibility for visually impaired players',
     network: 'Dev Discourse',
-    url: 'https://disabilitynewsdigest.substack.com/p/the-last-leg-promotes-disability#:~:text=Championing%20Accessibility%20in,platform%20called%20Audemy.',
+    url: 'https://www.devdiscourse.com/article/education/3358683-ai-powered-audio-learning-boosts-accessibility-for-visually-impaired-students',
   },
   {
     image: 'Disabilitynewsdigest.png',
     text: 'Crystal Yang is transforming gaming for blind and visually impaired players through Audemy',
     network: 'Disability News Digest',
-    url: 'https://disabilitynewsdigest.substack.com/p/the-last-leg-promotes-disability',
+    url: 'https://disabilitynewsdigest.substack.com/p/the-last-leg-promotes-disability#:~:text=Championing%20Accessibility%20in,platform%20called%20Audemy.',
   },
   {
     image: 'stanford.png',

--- a/src/pages/Impact/PressList/PressList.vue
+++ b/src/pages/Impact/PressList/PressList.vue
@@ -145,7 +145,7 @@ const items = [
     image: 'stanford.png',
     text: 'Audemy, an Al platform for Accessible Gaming through personalized Audio-Based Learning for Blind Players',
     network: 'Stanford Scale',
-    url: 'https://scale.stanford.edu/genai/repository/al-accessible-education-personalized-audio-based-learning-blind-students',
+    url: 'https://scale.stanford.edu/ai/repository/ai-accessible-education-personalized-audio-based-learning-blind-students',
   },
   {
     image: 'EV-resized.png',


### PR DESCRIPTION
# Summary
- Fix broken (`404`) links for Impact page and Press List cards
- Replace incorrect/duplicate URL for "Dev Discourse" link
- Add direct link to Audemy mention for long "Disability News Digest" article
- Re-run Prettier for consistent formatting

---

# Before / After

| Before (`404`) | After (Fixed) |
| :---: | :---: |
| <img width="300" alt="404 Florida" src="https://github.com/user-attachments/assets/5e2c3b78-d7f2-4f9a-b6c5-2a55af290598" /> | <img width="300" alt="Florida fixed" src="https://github.com/user-attachments/assets/f7221d14-7be5-4e48-b4c6-909e99308765" /> | 
| <img width="300" alt="404 IDHS" src="https://github.com/user-attachments/assets/ef2fa57f-ce44-4e1e-b470-21f1793e61e8" /> | <img width="300" alt="IDHS fixed" src="https://github.com/user-attachments/assets/6f57dc91-1431-4437-96ba-2b3231e540aa" /> |
| <img width="300" alt="404 KSSDB org" src="https://github.com/user-attachments/assets/95f0e926-d3fc-4c13-9f17-62093df3c8ac" /> | <img width="300" alt="fixed KSSB org" src="https://github.com/user-attachments/assets/aa12853d-096a-4394-9621-268590fd4f94" /> | 
| <img width="300" alt="404 stanford scale" src="https://github.com/user-attachments/assets/c13e4028-ac07-4edb-b793-02fc056faf0c" /> | <img width="300" alt="stanford scale fixed" src="https://github.com/user-attachments/assets/918edb06-1894-487d-96f9-41f1d5eee7bc" /> | 

---

# Manual Tests

> Broken links are now functional:

- [ ] Florida State School for the Blind: https://www.fsdbk12.org 
- [ ] Illinois School for the Visually Impaired: https://www.dhs.state.il.us
- [ ] KSSB: https://kansasblind.gov/
- [ ] Stanford Scale: https://scale.stanford.edu/ai/repository/ai-accessible-education-personalized-audio-based-learning-blind-students
- [ ] Dev Discourse: https://www.devdiscourse.com/article/education/3358683-ai-powered-audio-learning-boosts-accessibility-for-visually-impaired-students