### PR TITLE
fix: `404` Katy Hacks link & Improve SR Accessibility

### DIFF
--- a/src/pages/AudioConsole/AudioConsole.vue
+++ b/src/pages/AudioConsole/AudioConsole.vue
@@ -147,6 +147,7 @@ const impactCardsData = [
           <a
             href="#learn-more"
             class="page-button orange-button mobile:h-auto w-[180px] sm:w-[350px] px-5 py-3"
+            aria-label="Learn more about Buzzle"
           >
             Learn More
           </a>
@@ -369,14 +370,14 @@ const impactCardsData = [
           </p>
         </h1>
 
-        <!-- Learn More Button -->
+        <!-- Get in Touch Button -->
         <div class="page-button-flex">
           <a
             href="mailto:connect@audemy.org"
             target="_blank"
             class="page-button blue-button mobile:h-auto w-[180px] sm:w-[350px] px-5 py-3"
           >
-            Learn More
+            Get in Touch
           </a>
         </div>
       </div>

--- a/src/pages/Impact/PressList/PressList.vue
+++ b/src/pages/Impact/PressList/PressList.vue
@@ -275,6 +275,7 @@ onUnmounted(() => {
             <button
               @click="toggleShowAll"
               class="page-button blue-button px-10 py-3 mobile:h-auto md:w-[300px]"
+              :aria-label="showAll ? 'Show less articles' : 'See more articles'"
             >
               {{ showAll ? 'Show Less' : 'See More' }}
             </button>

--- a/src/pages/OurProjects/Events/KatyYouthHacks/KatyYouthHacks.vue
+++ b/src/pages/OurProjects/Events/KatyYouthHacks/KatyYouthHacks.vue
@@ -53,11 +53,11 @@
       </div>
       <div class="page-button-flex justify-center md:justify-start">
         <a
-          href="https://katyhacks.org/"
+          href="https://katyyouthhacks-2024.devpost.com/"
           target="_blank"
           class="page-button orange-button text-center md:px-3 md:w-[280px] px-9 mobile:h-auto py-3"
         >
-          Check upcoming events
+          About Katy Youth Hacks
         </a>
       </div>
     </div>


### PR DESCRIPTION
# Summary
- Addresses accessibility issues ([WCAG 2.4.4: Link Purpose](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html))  and broken "Katy Youth Hacks" links across "Impact," "Press List," and "Buzzle" sections

---

# Fixes & WCAG Updates

## Impact Page
- Fixed Katy Youth Hacks `404` link to a functional Devpost URL (https://katyyouthhacks-2024.devpost.com/)
- Updated outdated button label for accuracy: <kbd>"Check upcoming events"</kbd> to <kbd>"About Katy Youth Hacks"</kbd>

## Press List
- Added dynamic `aria-label` to toggle button for SR clarity (<kbd>"See more articles"</kbd> / <kbd>"Show less articles"</kbd>)

## Buzzle Page
- Resolved duplicate, vague <kbd>"Learn More"</kbd> button labels for Screen Reader (SR) output clarity: 
  - 1. Updated contact (email) button to <kbd>"Get in Touch"</kbd>
  - 2. Added a descriptive `aria-label` (<kbd>"Learn more about Buzzle"</kbd>) to the jump link

---

# Vercel Previews

## a. Fix `404` & Outdated Button Label: "Katy Youth Hacks"
| Before | After |
| :---: | :--: |
| <i>Outdated text (refers to 2024)</i><br/><img src="https://github.com/user-attachments/assets/12daa2fc-c29a-41ea-8ba4-3974c4278acf" width="500" /> | <i>Updated text (links to Devpost archive)</i><br/><img src="https://github.com/user-attachments/assets/de8ab33d-a513-4fdd-acc1-d0fa7d5d6104" width="500" /> |
| <img src="https://github.com/user-attachments/assets/5245db9d-e73c-4533-a7a6-c271d2ceabbe" width="500" /> | <img src="https://github.com/user-attachments/assets/cdf3cd1c-d037-4a62-9a5f-82ca09ab353b" width="500" /> |

## b. SR Clarity: Buzzle Buttons
| <kbd>"Learn More"</kbd> (jump link) | <kbd>"Get in Touch"</kbd> (email button) |
| :---: | :--:|
| <i>Same text with new `aria-label`</i><br/><img src="https://github.com/user-attachments/assets/4192a0d5-0310-46d2-af54-d00fbf2346a5" width="500" /> | <i>Resolved duplicate, vague button label <br/>(<kbd>"Learn More"</kbd> ➔ <kbd>"Get in Touch"</kbd>)</i><br/><img src="https://github.com/user-attachments/assets/56d15377-14a9-40a0-8776-f87c38af05cc" width="500" /> |

## c. SR Clarity: Press List Button

| Before | After |
| :---: | :--: |
| <i>Vague button labels</i><br/><img src="https://github.com/user-attachments/assets/170632bc-2ce4-4eb8-931c-3dbcea2a8586" width="500" /> | <i>Same text with new `aria-label`</i><br/><img src="https://github.com/user-attachments/assets/cc1ac05a-1811-4833-a6a0-6851ebc59573" width="500" /> |
| <img src="https://github.com/user-attachments/assets/3be89ea2-036d-45d5-a49f-9901bbaf2c05" width="500" /> | <img src="https://github.com/user-attachments/assets/1fca88d8-ded7-495a-bb17-a58e9b31f5bb" width="500" /> |

---

# Manual Tests
- **Links:** Fixed `404` and affected links in PR remain functional
- **VoiceOver:** SR output matches updated button `aria-label`s
- **Local dev + personal Vercel deployment:** No console errors
- **Sanity/Regression Check:** Games remain functional; sampled 1 game per category