### PR TITLE
# fix: Spelling Bee STT API/homophone bug for “run”

### DIFF
--- a/public/assets/questionsDb/spellingBeeDB.json
+++ b/public/assets/questionsDb/spellingBeeDB.json
@@ -11,7 +11,7 @@
         { "Q": "How do you spell 'box'?", "A": ["b o x"] },
         { "Q": "How do you spell 'car'?", "A": ["c a r"] },
         { "Q": "How do you spell 'man'?", "A": ["m a n"] },
-        { "Q": "How do you spell 'run'?", "A": ["r u n"] },
+        { "Q": "How do you spell 'jog'?", "A": ["j o g"] },
         { "Q": "How do you spell 'top'?", "A": ["t o p"] },
         { "Q": "How do you spell 'cup'?", "A": ["c u p"] },
         { "Q": "How do you spell 'bed'?", "A": ["b e d"] },


### PR DESCRIPTION
# Summary
* Resolves Spelling Bee transcription bug: STT API often misinterprets <kbd>“run”</kbd> (verb) as <kbd>“are you in”</kbd> (phrase)
* Swaps <kbd>"run"</kbd> with <kbd>"jog"</kbd> in `spellingBeeDB.json` to avoid homophone ambiguity 
* Ensures players are no longer incorrectly penalized for accurate spelling

> [!NOTE] 
> Decided against appending <kbd>“are you in”</kbd> to the database as an acceptable answer; since it is a phrase and not a synonym for the verb <kbd>"run"</kbd> (otherwise, it'd be incorrect/misleading for students)

---

# Vercel Previews
| Before (Game Bug: <kbd>"run"</kbd> misinterpreted as <kbd>"are you in"</kbd>) | 
| :---: |
| <img src="https://github.com/user-attachments/assets/10e2cdaa-9cca-4460-a78c-39be81fcc337" width="500" /> | 

| After (Updated 3-Letter/Easy Verb: <kbd>"jog"</kbd>) |
| :---: |
| <img src="https://github.com/user-attachments/assets/93a4f198-4458-47de-81bf-731bfe3bfff8" width="500" /> |

---

# Manual Tests
* **Local dev + personal Vercel deployment:** No console errors
* **Regression Check**
    * Confirmed <kbd>"jog"</kbd> transcribes/scores correctly
    * Games remain function; sampled 1+ game per category 
