### PR TITLE
Update privacy disclosures and legal-page design

### DIFF
--- a/src/components/AccountPages/Banner.vue
+++ b/src/components/AccountPages/Banner.vue
@@ -6,6 +6,15 @@ import YellowStar from '/assets/images/testimonials/star.svg';
 import BlueStar from '/assets/images/about-us/blueStar2.svg';
 import Bulb from '/assets/images/about-us/bulb.png';
 import Glasses from '/assets/images/impact/glasses.svg';
+import Puzzle from '/assets/images/game-toolkit/puzzle.png';
+import SpeechBubble from '/assets/images/impact/speech-bubble.png';
+import Key from '/assets/images/audio-console/key.png';
+import Research from '/assets/images/studio/research.png';
+import Accessibility from '/assets/images/studio/accessibility.png';
+import School from '/assets/images/impact/school.png';
+import Microphone from '/assets/images/techShowcase/microphone.png';
+import GameControl from '/assets/images/game-toolkit/game-control.png';
+import Checklist from '/assets/images/studio/checklist-v2.png';
 
 import { useDeviceDetection } from '../../composables/useDeviceDetection';
 const { isTablet, isMobile, isDesktop } = useDeviceDetection();
@@ -31,6 +40,21 @@ const props = defineProps({
     required: false,
   },
   isPageShort: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  showExtraDecorations: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  anchorCharacterTop: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  denseDecorations: {
     type: Boolean,
     required: false,
     default: false,
@@ -64,7 +88,12 @@ const props = defineProps({
         class="absolute z-10"
         alt=""
         :class="[
-          isDesktop ? 'w-[70px] right-[8%] top-[23%]' : '',
+          isDesktop && anchorCharacterTop
+            ? 'w-[70px] right-[8%] top-[230px]'
+            : '',
+          isDesktop && !anchorCharacterTop
+            ? 'w-[70px] right-[8%] top-[23%]'
+            : '',
           isTablet ? 'w-[60px] right-[8%] top-[25%]' : '',
           isMobile ? 'w-[50px] right-[8%] top-[21%]' : '',
         ]"
@@ -75,7 +104,12 @@ const props = defineProps({
         class="absolute z-10"
         alt=""
         :class="[
-          isDesktop ? 'w-[65px] right-[40%] top-[15%]' : '',
+          isDesktop && anchorCharacterTop
+            ? 'w-[65px] right-[40%] top-[205px]'
+            : '',
+          isDesktop && !anchorCharacterTop
+            ? 'w-[65px] right-[40%] top-[15%]'
+            : '',
           isTablet ? 'w-[60px] left-[75%] top-[20%]' : '',
           isMobile ? 'w-[50px] left-[70%] top-[20%]' : '',
         ]"
@@ -86,7 +120,12 @@ const props = defineProps({
         class="w-[65px] absolute z-10"
         alt=""
         :class="[
-          isDesktop ? 'w-[70px] left-[8%] top-[22%]' : '',
+          isDesktop && anchorCharacterTop
+            ? 'w-[70px] left-[8%] top-[225px]'
+            : '',
+          isDesktop && !anchorCharacterTop
+            ? 'w-[70px] left-[8%] top-[22%]'
+            : '',
           isTablet ? 'left-[21%] top-[20%]' : '',
           isMobile ? 'left-[18%] top-[20%]' : '',
         ]"
@@ -103,21 +142,26 @@ const props = defineProps({
           isTablet ? 'w-[50px] left-[12%] top-[60%]' : '',
           isMobile ? 'w-[50px] left-[10%] top-[53%]' : '',
         ]"
+        v-if="!(isDesktop && anchorCharacterTop)"
         loading="lazy"
       />
       <img
         :src="CarlImgPath"
         ref="imgRef"
-        class="object-contain absolute left-[50%] translate-x-[-50%] top-[50%] translate-y-[-50%] z-10"
+        class="object-contain absolute left-[50%] translate-x-[-50%] z-10"
         alt=""
         :class="[
-          isDesktop
-            ? 'top-[40%] max-h-[80vw] max-w-[80vw/3]'
-            : 'max-h-[200px] max-w-[80vw]',
-
-          !isPageShort && isDesktop ? 'w-[160px]' : '',
-          isPageShort && isDesktop ? 'w-[130px]' : '',
-
+          isDesktop && anchorCharacterTop
+            ? 'top-[24px] w-[160px] h-[170px] max-w-[70%]'
+            : '',
+          isDesktop && !anchorCharacterTop
+            ? 'top-[40%] translate-y-[-50%] max-h-[80vw] max-w-[80vw/3]'
+            : '',
+          !anchorCharacterTop && !isPageShort && isDesktop ? 'w-[160px]' : '',
+          !anchorCharacterTop && isPageShort && isDesktop ? 'w-[130px]' : '',
+          !isDesktop
+            ? 'top-[50%] translate-y-[-50%] max-h-[200px] max-w-[80vw]'
+            : '',
           !isDesktop && isImageWide ? 'w-[150px]' : '',
           !isDesktop && !isImageWide ? 'h-[130px]' : '',
         ]"
@@ -135,6 +179,7 @@ const props = defineProps({
           isTablet ? 'w-[48px] right-[15%] top-[55%]' : '',
           isMobile ? 'w-[40px] right-[13%] top-[50%]' : '',
         ]"
+        v-if="!(isDesktop && anchorCharacterTop)"
         loading="lazy"
       />
       <img
@@ -148,8 +193,142 @@ const props = defineProps({
           isTablet ? 'w-[48px] left-[12%] top-[22%]' : '',
           isMobile ? 'w-[40px] left-[10%] top-[20%]' : '',
         ]"
+        v-if="!(isDesktop && anchorCharacterTop)"
         loading="lazy"
       />
+      <div
+        v-if="isDesktop && showExtraDecorations && anchorCharacterTop"
+        class="pointer-events-none absolute inset-x-0 top-[330px] bottom-[140px] z-10 flex flex-col justify-between"
+      >
+        <div class="flex justify-start pl-[12%]">
+          <img
+            :src="Puzzle"
+            class="h-[56px] w-[56px] object-contain rotate-[-8deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-end pr-[12%]">
+          <img
+            :src="Research"
+            class="h-[58px] w-[58px] object-contain rotate-[7deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div v-if="denseDecorations" class="flex justify-start pl-[18%]">
+          <img
+            :src="School"
+            class="h-[58px] w-[58px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div
+          :class="
+            denseDecorations
+              ? 'flex justify-end pr-[18%]'
+              : 'flex justify-start pl-[18%]'
+          "
+        >
+          <img
+            :src="SpeechBubble"
+            class="h-[58px] w-[58px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div v-if="denseDecorations" class="flex justify-start pl-[12%]">
+          <img
+            :src="Microphone"
+            class="h-[54px] w-[54px] object-contain rotate-[-6deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-end pr-[18%]">
+          <img
+            :src="Accessibility"
+            class="h-[58px] w-[58px] object-contain rotate-[5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-start pl-[12%]">
+          <img
+            :src="Glasses"
+            class="h-[54px] w-[60px] object-contain rotate-[-6deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-end pr-[12%]">
+          <img
+            :src="Bulb"
+            class="h-[56px] w-[56px] object-contain rotate-[12deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div v-if="denseDecorations" class="flex justify-start pl-[18%]">
+          <img
+            :src="GameControl"
+            class="h-[56px] w-[56px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div
+          :class="
+            denseDecorations
+              ? 'flex justify-end pr-[18%]'
+              : 'flex justify-start pl-[18%]'
+          "
+        >
+          <img
+            :src="Book"
+            class="h-[54px] w-[60px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div v-if="denseDecorations" class="flex justify-start pl-[12%]">
+          <img
+            :src="Checklist"
+            class="h-[56px] w-[56px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-end pr-[18%]">
+          <img
+            :src="Key"
+            class="h-[78px] w-[78px] object-contain rotate-[14deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+      </div>
+      <template v-else-if="isDesktop && showExtraDecorations">
+        <img
+          :src="Puzzle"
+          class="absolute z-10 left-[14%] top-[32%] w-[55px] rotate-[-8deg]"
+          alt=""
+          loading="lazy"
+        />
+        <img
+          :src="SpeechBubble"
+          class="absolute z-10 right-[12%] top-[54%] w-[58px] rotate-[6deg]"
+          alt=""
+          loading="lazy"
+        />
+        <img
+          :src="Key"
+          class="absolute z-10 left-[20%] top-[85%] w-[88px] rotate-[-16deg]"
+          alt=""
+          loading="lazy"
+        />
+      </template>
     </div>
     <div v-if="isDesktop" class="z-0">
       <svg

--- a/src/pages/Footer/PrivacyPolicy.vue
+++ b/src/pages/Footer/PrivacyPolicy.vue
@@ -2,40 +2,6 @@
 import Banner from '../../components/AccountPages/Banner.vue';
 import Header from '../../components/Header/Header.vue';
 import Footer from '../../components/Footer/Footer.vue';
-
-// List of 'Privacy Policy' sections
-const policySections = [
-  {
-    header: `We Don't Collect Personal Data`,
-    details: `Audemy is a safe space for kids. We do not collect, store, or share any personal information.`,
-  },
-  {
-    header: 'For Kids, with Care',
-    details: `Audemy is built especially for blind and visually impaired students. We designed everything to be private and accessible. You can play our games and learn without an account or providing any personal details.`,
-  },
-  {
-    header: 'COPPA-Compliant',
-    details: `We follow the
-          <a
-            href="https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa"
-            target="_blank"
-            class="page-link"
-          >
-            Children's Online Privacy Protection Act
-          </a>
-          (COPPA). Since we don't collect any information from users under 13—or
-          anyone, really—there's nothing for us to protect. And that's exactly
-          how we like it.`,
-  },
-  {
-    header: 'Anonymous Use Only',
-    details: `All interactions with Audemy are completely anonymous. Your activity is not tracked, and we do not use cookies or analytics tools that collect user data.`,
-  },
-  {
-    header: 'Questions?',
-    details: `If you're a parent, teacher, or guardian and would like to learn more, contact us at <a href="mailto:connect@audemy.org" class="page-link">connect@audemy.org</a>.`,
-  },
-];
 </script>
 
 <template>
@@ -50,43 +16,186 @@ const policySections = [
       bgColor="#B1C7D0"
       curveColor="#E5F0F5"
       :isPageShort="true"
+      :showExtraDecorations="true"
+      :anchorCharacterTop="true"
+      :denseDecorations="true"
     />
-    <div
+    <main
       class="form-container-view-height text-left lg:col-span-2 lg:pb-[50px]"
     >
       <h1 class="form-title ml-[10%]">Privacy Policy</h1>
       <br />
       <div class="form-description">
         <p>
-          <i><span class="font-semibold">Last updated:</span> July 30, 2025</i>
+          <i><span class="font-semibold">Last updated:</span> August 19, 2026</i>
         </p>
         <br />
         <p>
-          At <span class="text-primary-color font-bold">Audemy</span>, we
-          respect and take your privacy very seriously. We created this policy
-          to explain—clearly and simply—how we handle your information.
+          Audemy is operated by Audiobvi Education. This policy explains what
+          information Audemy collects through audemy.org, why we use it, and
+          the choices available to users, parents, guardians, and educators.
         </p>
-        <div v-for="(policy, n) in policySections" :key="n">
-          <h2 class="page-subheader">{{ policy.header }}</h2>
-          <p v-html="policy.details"></p>
-          <br />
-          <template v-if="n == 0">
-            <p
-              class="font-semibold text-primary-color border-b-2 border-primary-color"
-            >
-              That means:
-            </p>
-            <ul class="list-disc text-left ml-[15%] lg:ml-[20%]">
-              <li>No names</li>
-              <li>No email addresses</li>
-              <li>No phone numbers</li>
-              <li>No photos, voice recordings, or other personal content</li>
-              <li>No cookies or trackers</li>
-            </ul>
-          </template>
-        </div>
+
+        <h2 class="page-subheader">Using Audemy without an account</h2>
+        <p>
+          Many public pages and games can be used without creating an account.
+          The site still receives basic technical and analytics information
+          when someone visits, as described below.
+        </p>
+
+        <h2 class="page-subheader">Information we collect</h2>
+        <ul class="list-disc text-left ml-[8%] lg:ml-[12%] space-y-3">
+          <li>
+            <span class="font-semibold">Account information:</span> If you
+            create an account, we collect your name, email address, school, and
+            password. Passwords are hashed before they are stored.
+          </li>
+          <li>
+            <span class="font-semibold">Google sign-in information:</span> If
+            you sign in with Google, Google provides your name, email address,
+            profile image, and a sign-in token. We may also ask for your school.
+          </li>
+          <li>
+            <span class="font-semibold">Session and activity information:</span>
+            We use an Audemy session cookie to keep you signed in. It contains
+            an authentication token and, on some sign-in paths, basic account
+            information. We also use temporary browser session storage to
+            remember a selected game category while you navigate the site.
+          </li>
+          <li>
+            <span class="font-semibold">Game activity:</span> During a game,
+            Audemy temporarily processes answers, scores, difficulty, and
+            recognized speech in the browser to run the game and provide
+            feedback. The current game flow does not save longitudinal progress
+            to an account.
+          </li>
+          <li>
+            <span class="font-semibold">Technical information:</span> Our
+            systems and service providers may receive IP addresses, browser and
+            device information, requested pages, referring pages, timestamps,
+            and login or signup attempts. We use this information to operate,
+            secure, and troubleshoot the site.
+          </li>
+          <li>
+            <span class="font-semibold">Communications:</span> If you contact
+            Audemy or request a password reset, we process the email address and
+            message information needed to respond or send the requested email.
+          </li>
+        </ul>
+
+        <h2 class="page-subheader">Microphone and speech features</h2>
+        <p>
+          Some games offer voice input. These features ask for microphone
+          permission and use the browser's speech-recognition service to turn
+          speech into text for the game. Depending on the browser or device,
+          audio may be processed by the browser, operating-system provider, or
+          another speech-service provider under that provider's privacy terms.
+          Recognized speech is temporarily handled as text in the browser.
+          Audemy does not intentionally send raw microphone recordings or those
+          recognized transcripts to its own database through these game
+          features.
+        </p>
+        <br />
+        <p>
+          Audemy also uses Google Cloud text-to-speech to generate some audio.
+          Text needed to generate that audio may be sent to Google Cloud.
+        </p>
+
+        <h2 class="page-subheader">Analytics, advertising, and cookies</h2>
+        <p>
+          Audemy uses Google Analytics to understand visits and how the site is
+          used. Google Analytics may use cookies or similar identifiers and may
+          receive page activity, device and browser information, referring
+          pages, and approximate location derived from an IP address. Audemy may
+          also use Google Ads to measure outreach or promote Audemy. Google may
+          connect analytics or ad interactions according to its own settings
+          and privacy terms.
+        </p>
+        <br />
+        <p>
+          The Audemy session cookie can remain for up to seven days. Google and
+          embedded services may set their own cookies. You can limit cookies in
+          your browser and review Google's controls at
+          <a
+            href="https://myadcenter.google.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="page-link"
+            >My Ad Center</a
+          >. Blocking the Audemy session cookie may prevent account login from
+          working.
+        </p>
+
+        <h2 class="page-subheader">How we use information</h2>
+        <ul class="list-disc text-left ml-[8%] lg:ml-[12%] space-y-3">
+          <li>Provide accounts, games, audio, and other site features.</li>
+          <li>Authenticate users and send password-reset messages.</li>
+          <li>Understand site use and improve accessibility and reliability.</li>
+          <li>Protect the site, prevent abuse, and troubleshoot problems.</li>
+          <li>Measure outreach and communicate about Audemy's services.</li>
+        </ul>
+
+        <h2 class="page-subheader">Service providers and external content</h2>
+        <p>
+          Audemy relies on service providers to run the site. These include
+          Vercel for deployment, a database provider, Gmail for password-reset
+          email, and Google services for analytics, advertising, sign-in,
+          fonts, and text-to-speech. Some pages also load external content such
+          as YouTube videos or TomTom maps. Those providers may receive
+          technical information or set cookies when their services load. Their
+          handling of information is governed by their own policies.
+        </p>
+
+        <h2 class="page-subheader">Children's privacy</h2>
+        <p>
+          Audemy is designed for students, including children. The current
+          signup form does not ask for a date of birth. A child under 13 should
+          not create an account or submit personal information unless a parent,
+          guardian, or authorized school has approved and arranged the use. A
+          parent or guardian who believes a child submitted information without
+          appropriate authorization should contact us so we can review the
+          account and delete information when appropriate.
+        </p>
+
+        <h2 class="page-subheader">Retention, access, and deletion</h2>
+        <p>
+          The current site does not offer a self-service account-deletion tool.
+          To ask what account information Audemy has, request a correction, or
+          request deletion, email us using the address below. We may need to
+          verify the request. The current system does not define a fixed
+          automatic deletion period for accounts. Some information may remain
+          for security, legal, or backup purposes.
+        </p>
+
+        <h2 class="page-subheader">Security</h2>
+        <p>
+          Account passwords are hashed before they are stored. No website or
+          storage system is completely secure, so we cannot guarantee absolute
+          security.
+        </p>
+
+        <h2 class="page-subheader">International use</h2>
+        <p>
+          Audemy can be accessed outside the United States. Information may be
+          processed in the United States or in other locations where our service
+          providers operate.
+        </p>
+
+        <h2 class="page-subheader">Changes to this policy</h2>
+        <p>
+          We may update this policy as Audemy's services change. The date at the
+          top shows when the policy was last updated.
+        </p>
+
+        <h2 class="page-subheader">Contact us</h2>
+        <p>
+          For privacy questions or requests, contact
+          <a href="mailto:connect@audemy.org" class="page-link"
+            >connect@audemy.org</a
+          >.
+        </p>
       </div>
-    </div>
+    </main>
   </div>
   <Footer />
 </template>

--- a/src/pages/Footer/TermsOfUse.vue
+++ b/src/pages/Footer/TermsOfUse.vue
@@ -11,11 +11,10 @@ const termSections = [
   },
   {
     header: 'Data and Privacy',
-    details: `Audemy does not collect, store, or share any personal data from
-              users. Our Services are designed to be used without requiring
-              accounts, personal information, or data tracking. Because no user
-              data is collected or stored, there is no risk of your personal
-              information being sold or disclosed.`,
+    details: `Audemy offers optional accounts and uses analytics, cookies, and
+              service providers to operate and improve the Services. Our
+              Privacy Policy explains the information we collect, how we use it,
+              and how to request access, correction, or deletion.`,
   },
   {
     header: 'Purpose of Services',
@@ -27,10 +26,9 @@ const termSections = [
   },
   {
     header: 'Limitation of Liability',
-    details: `Our Services are provided “as-is,” without warranties of any kind.
-              Since no personal data is collected or stored, Audemy is not
-              responsible for any data loss or unauthorized access to personal
-              information.`,
+    details: `Our Services are provided “as-is,” without warranties of any kind,
+              to the extent permitted by law. Please review our Privacy Policy
+              for information about data handling and security.`,
   },
   {
     header: 'Contact Us',
@@ -77,6 +75,8 @@ const contactLinkClasses = ['page-link', 'justify-self-end'];
       :CarlImgPath="'/assets/images/SignUpImg/signup-carl.png'"
       bgColor="#B1C7D0"
       curveColor="#E5F0F5"
+      :showExtraDecorations="true"
+      :anchorCharacterTop="true"
     />
     <div
       class="form-container-view-height lg:col-span-2 lg:pb-[50px] text-left"
@@ -85,7 +85,7 @@ const contactLinkClasses = ['page-link', 'justify-self-end'];
       <br />
       <div class="form-description">
         <p>
-          <i><span class="font-semibold">Last updated:</span> July 30, 2025</i>
+          <i><span class="font-semibold">Last updated:</span> August 19, 2026</i>
         </p>
         <br />
         <p>


### PR DESCRIPTION
## Summary

- Rewrites the Privacy Policy to match Audemy's current account, authentication, analytics, cookie, speech, email, and service-provider behavior.
- Removes claims that users are fully anonymous, that no personal data is collected, and that the current implementation is already COPPA-compliant.
- Updates the Terms of Use so it no longer contradicts the Privacy Policy.
- Gives the Privacy Policy and Terms of Use a consistent legal-page sidebar, with Carl at the top and page-length-aware illustrations distributed down the desktop sidebar.

## What the policy now covers

- Optional accounts, including name, email, school, and hashed passwords
- Google sign-in
- Session cookies, browser session storage, IP addresses, and rate limiting
- Google Analytics and possible Google Ads measurement
- Browser speech recognition and Google Cloud text-to-speech
- Password-reset email and external service providers
- Children's privacy, retention, access, correction, and deletion requests
- International processing and security limitations

## Verification

- `npm run build`
- `git diff --check`
- Desktop and mobile browser review of both legal pages
- Full-height sidebar review for the longer Privacy Policy and shorter Terms of Use layouts
- Secret-pattern scan across the changed files

## Follow-up engineering work

This PR corrects the public disclosures but does not change the underlying data flows. A separate security/privacy hardening pass should review user-data endpoint authorization, API response fields, password-reset logging, analytics consent timing, age/parental-consent handling, deletion tooling, and retention controls.
