### PR TITLE
Feature: Update Legal-Page Banner Design

### DIFF
--- a/src/components/AccountPages/Banner.vue
+++ b/src/components/AccountPages/Banner.vue
@@ -6,9 +6,18 @@ import YellowStar from '/assets/images/testimonials/star.svg';
 import BlueStar from '/assets/images/about-us/blueStar2.svg';
 import Bulb from '/assets/images/about-us/bulb.png';
 import Glasses from '/assets/images/impact/glasses.svg';
+import Puzzle from '/assets/images/game-toolkit/puzzle.png';
+import SpeechBubble from '/assets/images/impact/speech-bubble.png';
+import Key from '/assets/images/audio-console/key.png';
+import Research from '/assets/images/studio/research.png';
+import Accessibility from '/assets/images/studio/accessibility.png';
+import School from '/assets/images/impact/school.png';
+import Microphone from '/assets/images/techShowcase/microphone.png';
+import GameControl from '/assets/images/game-toolkit/game-control.png';
+import Checklist from '/assets/images/studio/checklist-v2.png';
 
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useDeviceDetection } from '../../composables/useDeviceDetection';
-const { isTablet, isMobile, isDesktop } = useDeviceDetection();
 
 // isImageWide: true if image width > height.
 // Helps Banner scale image: Reduces width for wide images, or height for tall ones.
@@ -35,6 +44,47 @@ const props = defineProps({
     required: false,
     default: false,
   },
+  showExtraDecorations: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  anchorCharacterTop: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  denseDecorations: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+});
+
+const {
+  isTablet: detectedTablet,
+  isMobile,
+  isDesktop: detectedDesktop,
+} = useDeviceDetection();
+const isAtDesktopGridWidth = ref(false);
+const isDesktop = computed(
+  () =>
+    detectedDesktop.value ||
+    (props.anchorCharacterTop && isAtDesktopGridWidth.value),
+);
+const isTablet = computed(() => detectedTablet.value && !isDesktop.value);
+
+const checkBannerLayout = () => {
+  isAtDesktopGridWidth.value = window.innerWidth >= 1024;
+};
+
+onMounted(() => {
+  checkBannerLayout();
+  window.addEventListener('resize', checkBannerLayout);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', checkBannerLayout);
 });
 </script>
 
@@ -64,7 +114,12 @@ const props = defineProps({
         class="absolute z-10"
         alt=""
         :class="[
-          isDesktop ? 'w-[70px] right-[8%] top-[23%]' : '',
+          isDesktop && anchorCharacterTop
+            ? 'w-[70px] right-[8%] top-[230px]'
+            : '',
+          isDesktop && !anchorCharacterTop
+            ? 'w-[70px] right-[8%] top-[23%]'
+            : '',
           isTablet ? 'w-[60px] right-[8%] top-[25%]' : '',
           isMobile ? 'w-[50px] right-[8%] top-[21%]' : '',
         ]"
@@ -75,7 +130,12 @@ const props = defineProps({
         class="absolute z-10"
         alt=""
         :class="[
-          isDesktop ? 'w-[65px] right-[40%] top-[15%]' : '',
+          isDesktop && anchorCharacterTop
+            ? 'w-[65px] right-[40%] top-[205px]'
+            : '',
+          isDesktop && !anchorCharacterTop
+            ? 'w-[65px] right-[40%] top-[15%]'
+            : '',
           isTablet ? 'w-[60px] left-[75%] top-[20%]' : '',
           isMobile ? 'w-[50px] left-[70%] top-[20%]' : '',
         ]"
@@ -86,7 +146,12 @@ const props = defineProps({
         class="w-[65px] absolute z-10"
         alt=""
         :class="[
-          isDesktop ? 'w-[70px] left-[8%] top-[22%]' : '',
+          isDesktop && anchorCharacterTop
+            ? 'w-[70px] left-[8%] top-[225px]'
+            : '',
+          isDesktop && !anchorCharacterTop
+            ? 'w-[70px] left-[8%] top-[22%]'
+            : '',
           isTablet ? 'left-[21%] top-[20%]' : '',
           isMobile ? 'left-[18%] top-[20%]' : '',
         ]"
@@ -103,21 +168,24 @@ const props = defineProps({
           isTablet ? 'w-[50px] left-[12%] top-[60%]' : '',
           isMobile ? 'w-[50px] left-[10%] top-[53%]' : '',
         ]"
+        v-if="!(isDesktop && anchorCharacterTop)"
         loading="lazy"
       />
       <img
         :src="CarlImgPath"
         ref="imgRef"
-        class="object-contain absolute left-[50%] translate-x-[-50%] top-[50%] translate-y-[-50%] z-10"
+        class="object-contain absolute left-[50%] translate-x-[-50%] z-10"
         alt=""
         :class="[
-          isDesktop
+          isDesktop && anchorCharacterTop
+            ? 'top-[24px] w-[160px] h-[170px] max-w-[70%]'
+            : 'top-[50%] translate-y-[-50%]',
+          isDesktop && !anchorCharacterTop
             ? 'top-[40%] max-h-[80vw] max-w-[80vw/3]'
-            : 'max-h-[200px] max-w-[80vw]',
-
-          !isPageShort && isDesktop ? 'w-[160px]' : '',
-          isPageShort && isDesktop ? 'w-[130px]' : '',
-
+            : '',
+          !anchorCharacterTop && !isPageShort && isDesktop ? 'w-[160px]' : '',
+          !anchorCharacterTop && isPageShort && isDesktop ? 'w-[130px]' : '',
+          !isDesktop ? 'max-h-[200px] max-w-[80vw]' : '',
           !isDesktop && isImageWide ? 'w-[150px]' : '',
           !isDesktop && !isImageWide ? 'h-[130px]' : '',
         ]"
@@ -135,6 +203,7 @@ const props = defineProps({
           isTablet ? 'w-[48px] right-[15%] top-[55%]' : '',
           isMobile ? 'w-[40px] right-[13%] top-[50%]' : '',
         ]"
+        v-if="!(isDesktop && anchorCharacterTop)"
         loading="lazy"
       />
       <img
@@ -148,8 +217,142 @@ const props = defineProps({
           isTablet ? 'w-[48px] left-[12%] top-[22%]' : '',
           isMobile ? 'w-[40px] left-[10%] top-[20%]' : '',
         ]"
+        v-if="!(isDesktop && anchorCharacterTop)"
         loading="lazy"
       />
+      <div
+        v-if="isDesktop && showExtraDecorations && anchorCharacterTop"
+        class="pointer-events-none absolute inset-x-0 top-[330px] bottom-[140px] z-10 flex flex-col justify-between"
+      >
+        <div class="flex justify-start pl-[12%]">
+          <img
+            :src="Puzzle"
+            class="h-[56px] w-[56px] object-contain rotate-[-8deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-end pr-[12%]">
+          <img
+            :src="Research"
+            class="h-[58px] w-[58px] object-contain rotate-[7deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div v-if="denseDecorations" class="flex justify-start pl-[18%]">
+          <img
+            :src="School"
+            class="h-[58px] w-[58px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div
+          :class="
+            denseDecorations
+              ? 'flex justify-end pr-[18%]'
+              : 'flex justify-start pl-[18%]'
+          "
+        >
+          <img
+            :src="SpeechBubble"
+            class="h-[58px] w-[58px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div v-if="denseDecorations" class="flex justify-start pl-[12%]">
+          <img
+            :src="Microphone"
+            class="h-[54px] w-[54px] object-contain rotate-[-6deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-end pr-[18%]">
+          <img
+            :src="Accessibility"
+            class="h-[58px] w-[58px] object-contain rotate-[5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-start pl-[12%]">
+          <img
+            :src="Glasses"
+            class="h-[54px] w-[60px] object-contain rotate-[-6deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-end pr-[12%]">
+          <img
+            :src="Bulb"
+            class="h-[56px] w-[56px] object-contain rotate-[12deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div v-if="denseDecorations" class="flex justify-start pl-[18%]">
+          <img
+            :src="GameControl"
+            class="h-[56px] w-[56px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div
+          :class="
+            denseDecorations
+              ? 'flex justify-end pr-[18%]'
+              : 'flex justify-start pl-[18%]'
+          "
+        >
+          <img
+            :src="Book"
+            class="h-[54px] w-[60px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div v-if="denseDecorations" class="flex justify-start pl-[12%]">
+          <img
+            :src="Checklist"
+            class="h-[56px] w-[56px] object-contain rotate-[-5deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+        <div class="flex justify-end pr-[18%]">
+          <img
+            :src="Key"
+            class="h-[78px] w-[78px] object-contain rotate-[14deg]"
+            alt=""
+            loading="lazy"
+          />
+        </div>
+      </div>
+      <template v-else-if="isDesktop && showExtraDecorations">
+        <img
+          :src="Puzzle"
+          class="absolute z-10 left-[14%] top-[32%] w-[55px] rotate-[-8deg]"
+          alt=""
+          loading="lazy"
+        />
+        <img
+          :src="SpeechBubble"
+          class="absolute z-10 right-[12%] top-[54%] w-[58px] rotate-[6deg]"
+          alt=""
+          loading="lazy"
+        />
+        <img
+          :src="Key"
+          class="absolute z-10 left-[20%] top-[85%] w-[88px] rotate-[-16deg]"
+          alt=""
+          loading="lazy"
+        />
+      </template>
     </div>
     <div v-if="isDesktop" class="z-0">
       <svg

--- a/src/pages/Footer/PrivacyPolicy.vue
+++ b/src/pages/Footer/PrivacyPolicy.vue
@@ -50,6 +50,9 @@ const policySections = [
       bgColor="#B1C7D0"
       curveColor="#E5F0F5"
       :isPageShort="true"
+      :showExtraDecorations="true"
+      :anchorCharacterTop="true"
+      :denseDecorations="true"
     />
     <div
       class="form-container-view-height text-left lg:col-span-2 lg:pb-[50px]"

--- a/src/pages/Footer/TermsOfUse.vue
+++ b/src/pages/Footer/TermsOfUse.vue
@@ -77,6 +77,8 @@ const contactLinkClasses = ['page-link', 'justify-self-end'];
       :CarlImgPath="'/assets/images/SignUpImg/signup-carl.png'"
       bgColor="#B1C7D0"
       curveColor="#E5F0F5"
+      :showExtraDecorations="true"
+      :anchorCharacterTop="true"
     />
     <div
       class="form-container-view-height lg:col-span-2 lg:pb-[50px] text-left"


### PR DESCRIPTION
## Problem / Feature
- The Privacy Policy and Terms of Use use the shared Banner component but lack page-length-aware visual treatment on desktop.
- Maintainer guidance on closed PR #323 requested that the Banner design be submitted separately from policy, account, and tracking changes.

## Approach
- Adds opt-in Banner props for top-anchored character art and page-length-aware educational decorations.
- Applies the denser illustration layout to Privacy Policy and the lighter layout to Terms of Use.
- Aligns the opted-in legal Banner with the `lg:grid` transition at exactly 1024px without changing the shared device-detection composable.
- Keeps existing Banner behavior unchanged for Login, Sign Up, reset, accessibility, and other non-opted-in pages.

## Dependencies / Configuration
- No dependencies added or updated.
- No configuration, environment-variable, schema, or deployment changes.

## Scope
- Targets `preprod`.
- Changes only:
  - `src/components/AccountPages/Banner.vue`
  - `src/pages/Footer/PrivacyPolicy.vue`
  - `src/pages/Footer/TermsOfUse.vue`
- No Privacy Policy or Terms text changes.
- No account, analytics, cookies, tracking, consent, or data-flow changes.

## Accessibility
- Keeps the Banner decorative with `aria-hidden="true"` and empty image alt text.
- Preserves existing legal-page content order and semantics.

## Screenshots / Logs
- Responsive browser captures were reviewed at the viewports listed below.
- Vercel preview is pending authorization from a member of Crystal’s Vercel team; this is not a build failure.

## Manual Tests
- `npm ci`
- `npm run build`
- `git diff --check`
- Added-line secret/security pattern scan
- Privacy Policy: live browser review at 390px, 768px, 1024px, and 1280px
- Terms of Use: live browser review at 1024px
- Shared-component regression: exact 1024px Login Banner DOM geometry comparison against untouched `preprod`
- Branch freshness: confirmed `preprod` did not move before publishing (`0 0` divergence)

## Review / Merge
- Requested label: `feature`
- At least one explicit approval is required before squash merge.
- Do not merge while required tests or preview authorization remain unresolved.

Closes #326
